### PR TITLE
Add hydration command for React hydration timing

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -130,25 +130,39 @@ $ next-browser ssr-goto http://localhost:3000/dashboard
 
 Use `goto` or `reload` afterward to restore normal behavior.
 
-### `capture-goto [url]`
+### `perf [url]`
 
-Record the full loading sequence of a page as a series of screenshots —
-from the initial PPR shell through hydration to the fully loaded state.
-Useful for seeing exactly how a page progressively reveals content and
-identifying where visual jank or long loading gaps occur.
+Profile a full page load — reloads the current page (or navigates to a
+URL) and collects Core Web Vitals and React hydration timing in one pass.
 
 ```
-$ next-browser capture-goto http://localhost:3024/vercel/~/deployments
-12 frames → /tmp/next-browser-capture-goto-1710000000000
+$ next-browser perf http://localhost:3000/dashboard
+# Page Load Profile — http://localhost:3000/dashboard
 
-frame-0000.png is the PPR shell. Remaining frames capture hydration → data.
+## Core Web Vitals
+  TTFB                   42ms
+  LCP               1205.3ms (img: /_next/image?url=...)
+  CLS                    0.03
+
+## React Hydration — 65.5ms (466.2ms → 531.7ms)
+  Hydrated                         65.5ms  (466.2 → 531.7)
+  Commit                            2.0ms  (531.7 → 533.7)
+  Waiting for Paint                 3.0ms  (533.7 → 536.7)
+  Remaining Effects                 4.1ms  (536.7 → 540.8)
+
+## Hydrated components (42 total, sorted by duration)
+  DeploymentsProvider                       8.3ms
+  NavigationProvider                        5.1ms
+  ...
 ```
 
-Frame 0 is the PPR shell (what the user sees instantly). Remaining frames
-show the page filling in. Read them with the Read tool to see the
-visual progression.
+**TTFB** — server response time (Navigation Timing API).
+**LCP** — when the largest visible element painted, plus what it was.
+**CLS** — cumulative layout shift score (lower is better).
+**Hydration** — React reconciler phases and per-component cost (requires
+React profiling build / `next dev`; production strips `console.timeStamp`).
 
-Without a URL argument, captures the current page (re-navigates to it).
+Without a URL, reloads the current page. With a URL, navigates there first.
 
 ### `restart-server`
 
@@ -197,15 +211,24 @@ unlocked
 # PPR Shell Analysis
 # 131 boundaries: 3 dynamic holes, 128 static
 
-## Dynamic holes (suspended in shell)
-  Next.Metadata
-    rendered by: MetadataWrapper
-  TeamDeploymentsLayout at app/(dashboard)/[teamSlug]/.../layout.tsx:37:9
-    suspenders unknown: thrown Promise (library using throw instead of use())
-  TrackedSuspense at ../../packages/navigation-metrics/.../tracked-suspense.js:6:20
+## Summary
+- Top actionable hole: TrackedSuspense — usePathname (client-hook)
+- Suggested next step: This route segment is suspending on client hooks. Check loading.tsx first...
+- Most common root cause: usePathname (client-hook) affecting 1 boundary
+
+## Quick Reference
+| Boundary                   | Type              | Fallback source | Primary blocker           | Source                        | Suggested next step       |
+| ---                        | ---               | ---             | ---                       | ---                           | ---                       |
+| TrackedSuspense            | component         | unknown         | usePathname (client-hook) | tracked-suspense.js:6         | Push the hook-using cl... |
+| TeamDeploymentsLayout      | route-segment     | unknown         | unknown                   | layout.tsx:37                 | Inspect the nearest us... |
+| Next.Metadata              | component         | unknown         | unknown                   | unknown                       | No primary blocker was... |
+
+## Detail
+  TrackedSuspense
     rendered by: TrackedSuspense > RootLayout > AppLayout
-    blocked by:
-      - usePathname (SSR): /vercel/~/deployments awaited in <FacePopover>
+    environments: SSR
+  TeamDeploymentsLayout
+    suspenders unknown: thrown Promise (library using throw instead of use())
 
 ## Static (pre-rendered in shell)
   GeistProvider at .../geist-provider.tsx:80:9
@@ -213,8 +236,10 @@ unlocked
   ...
 ```
 
-Each hole shows: boundary name + source, `rendered by:` ownership chain,
-`blocked by:` the dynamic calls (hooks, server APIs, scripts, cache, etc.)
+The **Quick Reference** table is the main overview — boundary, blocker,
+source, and suggested fix at a glance. The **Detail** section only appears
+for holes that have extra info (owner chains, environments, secondary
+blockers) not already in the table.
 
 **`errors` doesn't report while locked.** If the shell looks wrong (empty,
 bailed to CSR), unlock and `goto` the page normally, then run `errors`.
@@ -486,8 +511,9 @@ monolithic loading state, not the page.
 A meaningful shell is the real component tree with small, local fallbacks
 where data is genuinely pending. Getting there means the composition layer
 — the layouts and wrappers between those leaf boundaries — can't itself
-suspend. `ppr unlock` names what suspended (`blocked by:`) and where it
-sits (`rendered by:`). A suspend high in the tree is what collapses
+suspend. `ppr unlock`'s Quick Reference table names the primary blocker
+and source for each hole; the Detail section adds owner chains and
+secondary blockers. A suspend high in the tree is what collapses
 everything beneath it into one fallback.
 
 Work it top-down. For the component that's suspending: can the dynamic

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/next-browser",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Headed Playwright browser with React DevTools pre-loaded",
   "license": "MIT",
   "repository": {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -11,7 +11,7 @@
  * Module-level state: one browser context, one page, one PPR lock.
  */
 
-import { readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { readFileSync, mkdirSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { chromium, type BrowserContext, type Page } from "playwright";
@@ -158,7 +158,7 @@ export async function unlock() {
   // For goto case: the page auto-reloads. Wait for the new page to load
   // and React/DevTools to reconnect before trying to snapshot boundaries.
   await page.waitForLoadState("load").catch(() => {});
-  await new Promise((r) => setTimeout(r, 2000));
+  await waitForDevToolsReconnect(page);
 
   // Wait for all boundaries to resolve after unlock.
   await waitForSuspenseToSettle(page);
@@ -230,6 +230,25 @@ async function waitForSuspenseToSettle(p: Page) {
   }
 }
 
+/**
+ * Wait for React DevTools to reconnect after a page reload.
+ *
+ * After the goto case unlocks, the page auto-reloads and DevTools loses its
+ * renderer connection. Poll until the DevTools hook reports at least one
+ * renderer, or bail after 5s. This replaces the old hardcoded 2s sleep.
+ */
+async function waitForDevToolsReconnect(p: Page) {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const connected = await p.evaluate(() => {
+      const hook = (window as any).__REACT_DEVTOOLS_GLOBAL_HOOK__;
+      return hook?.rendererInterfaces?.size > 0;
+    }).catch(() => false);
+    if (connected) return;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+}
+
 // ── Navigation ───────────────────────────────────────────────────────────────
 
 /** Hard reload the current page. Returns the URL after reload. */
@@ -240,69 +259,137 @@ export async function reload() {
 }
 
 /**
- * Reload the page while capturing screenshots every ~150ms.
- * Stops when: load has fired AND no new layout-shift entries for 2s.
- * Hard timeout at 30s. Returns the list of screenshot paths plus any
- * LayoutShift entries observed during the reload.
- */
-/**
- * Lock PPR → goto → screenshot the shell → unlock → screenshot frames
- * until the page settles. Just PNGs in a directory — the AI reads them.
+ * Profile a page load: reload (or navigate to a URL) and collect Core Web
+ * Vitals (LCP, CLS, TTFB) plus React hydration timing.
  *
- * Frame 0 is always the PPR shell. Remaining frames capture the transition
- * through hydration and data loading. Stops after 3s of no visual change.
+ * CWVs come from PerformanceObserver and Navigation Timing API.
+ * Hydration timing comes from console.timeStamp entries emitted by React's
+ * profiling build (see the addInitScript interceptor in launch()).
+ *
+ * Returns structured data that the CLI formats into a readable report.
  */
-export async function captureGoto(url?: string) {
+export async function perf(url?: string) {
   if (!page) throw new Error("browser not open");
   const targetUrl = url || page.url();
-  const dir = join(tmpdir(), `next-browser-capture-goto-${Date.now()}`);
-  mkdirSync(dir, { recursive: true });
 
-  let frameIdx = 0;
+  // Install CWV observers before navigation so they capture everything.
+  await page.evaluate(() => {
+    (window as any).__NEXT_BROWSER_REACT_TIMING__ = [];
+    const cwv: any = { lcp: null, cls: 0, clsEntries: [] };
+    (window as any).__NEXT_BROWSER_CWV__ = cwv;
 
-  async function snap() {
-    await hideDevOverlay();
-    const path = join(dir, `frame-${String(frameIdx).padStart(4, "0")}.png`);
-    const buf = await page!.screenshot({ path }).catch(() => null);
-    frameIdx++;
-    return buf;
+    // Largest Contentful Paint
+    new PerformanceObserver((list) => {
+      const entries = list.getEntries();
+      if (entries.length > 0) {
+        const last = entries[entries.length - 1] as any;
+        cwv.lcp = {
+          startTime: Math.round(last.startTime * 100) / 100,
+          size: last.size,
+          element: last.element?.tagName?.toLowerCase() ?? null,
+          url: last.url || null,
+        };
+      }
+    }).observe({ type: "largest-contentful-paint", buffered: true });
+
+    // Cumulative Layout Shift
+    new PerformanceObserver((list) => {
+      for (const entry of list.getEntries() as any[]) {
+        if (!entry.hadRecentInput) {
+          cwv.cls += entry.value;
+          cwv.clsEntries.push({
+            value: Math.round(entry.value * 10000) / 10000,
+            startTime: Math.round(entry.startTime * 100) / 100,
+          });
+        }
+      }
+    }).observe({ type: "layout-shift", buffered: true });
+  });
+
+  // Navigate or reload to trigger a full page load.
+  if (url) {
+    await page.goto(targetUrl, { waitUntil: "load" });
+  } else {
+    await page.reload({ waitUntil: "load" });
   }
 
-  // PPR shell: lock suppresses hydration.
-  await lock();
-  await page.goto(targetUrl, { waitUntil: "load" }).catch(() => {});
-  await new Promise((r) => setTimeout(r, 300));
-  await snap();
+  // Wait for passive effects, late paints, and layout shifts to flush.
+  await new Promise((r) => setTimeout(r, 3000));
 
-  // Unlock → page reloads, hydrates, loads data.
-  const unlockDone = unlock();
-  await new Promise((r) => setTimeout(r, 200));
+  // Collect all metrics from the page.
+  const metrics = await page.evaluate(() => {
+    const cwv = (window as any).__NEXT_BROWSER_CWV__ ?? {};
+    const timing = (window as any).__NEXT_BROWSER_REACT_TIMING__ ?? [];
 
-  let lastChangeTime = Date.now();
-  let prevHash = "";
-  const SETTLE_MS = 3_000;
-  const HARD_TIMEOUT = 30_000;
-  const start = Date.now();
+    // TTFB from Navigation Timing API.
+    const nav = performance.getEntriesByType("navigation")[0] as PerformanceNavigationTiming | undefined;
+    const ttfb = nav
+      ? Math.round((nav.responseStart - nav.requestStart) * 100) / 100
+      : null;
 
-  while (true) {
-    const buf = await snap();
+    return { cwv, timing, ttfb };
+  }) as {
+    cwv: {
+      lcp: { startTime: number; size: number; element: string | null; url: string | null } | null;
+      cls: number;
+      clsEntries: { value: number; startTime: number }[];
+    };
+    timing: Array<{
+      label: string;
+      startTime: number;
+      endTime: number;
+      track: string;
+      trackGroup: string;
+      color: string;
+    }>;
+    ttfb: number | null;
+  };
 
-    let hash = "";
-    if (buf) {
-      let h = 0;
-      for (let i = 0; i < buf.length; i += 200) h = ((h << 5) - h + buf[i]) | 0;
-      hash = String(h);
-    }
-    if (hash !== prevHash) { lastChangeTime = Date.now(); prevHash = hash; }
+  // Process React hydration timing.
+  const phases = metrics.timing.filter((e) => e.trackGroup === "Scheduler ⚛" && e.endTime > e.startTime);
+  const components = metrics.timing.filter((e) => e.track === "Components ⚛" && e.endTime > e.startTime);
+  const hydrationPhases = phases.filter((e) => e.label === "Hydrated");
+  const hydratedComponents = components.filter((e) => e.color?.startsWith("tertiary"));
 
-    if (Date.now() - start > HARD_TIMEOUT) break;
-    if (lastChangeTime > 0 && Date.now() - lastChangeTime > SETTLE_MS) break;
-
-    await new Promise((r) => setTimeout(r, 150));
+  let hydrationStart = Infinity;
+  let hydrationEnd = 0;
+  for (const p of hydrationPhases) {
+    if (p.startTime < hydrationStart) hydrationStart = p.startTime;
+    if (p.endTime > hydrationEnd) hydrationEnd = p.endTime;
   }
 
-  await unlockDone.catch(() => {});
-  return { dir, frames: frameIdx };
+  const round = (n: number) => Math.round(n * 100) / 100;
+
+  return {
+    url: targetUrl,
+    ttfb: metrics.ttfb,
+    lcp: metrics.cwv.lcp,
+    cls: {
+      score: round(metrics.cwv.cls),
+      entries: metrics.cwv.clsEntries,
+    },
+    hydration: hydrationPhases.length > 0
+      ? {
+          startTime: round(hydrationStart),
+          endTime: round(hydrationEnd),
+          duration: round(hydrationEnd - hydrationStart),
+        }
+      : null,
+    phases: phases.map((p) => ({
+      label: p.label,
+      startTime: round(p.startTime),
+      endTime: round(p.endTime),
+      duration: round(p.endTime - p.startTime),
+    })),
+    hydratedComponents: hydratedComponents
+      .map((c) => ({
+        name: c.label,
+        startTime: round(c.startTime),
+        endTime: round(c.endTime),
+        duration: round(c.endTime - c.startTime),
+      }))
+      .sort((a, b) => b.duration - a.duration),
+  };
 }
 
 /**
@@ -479,96 +566,6 @@ async function hideDevOverlay() {
   await page.evaluate(() => {
     document.querySelectorAll("[data-nextjs-dev-overlay]").forEach((el) => el.remove());
   }).catch(() => {});
-}
-
-/**
- * Navigate to a URL and collect React hydration timing from console.timeStamp
- * entries emitted by React's profiling build. React calls
- * console.timeStamp(label, startTime, endTime, track, trackGroup, color)
- * where startTime/endTime are performance.now() values from the reconciler.
- *
- * The "Hydrated" label marks the render phase of hydration (reconciling
- * server-rendered HTML). Components hydrated in that pass use tertiary colors
- * on the "Components ⚛" track. Commit, layout effects, and passive effects
- * are logged as separate phases.
- *
- * Requires a React profiling build (enableProfilerTimer = true).
- * Production builds strip console.timeStamp calls — use next dev or
- * a profiling build to get data.
- */
-export async function hydration(url?: string) {
-  if (!page) throw new Error("browser not open");
-  const targetUrl = url || page.url();
-
-  // Clear any previous timing entries.
-  await page.evaluate(() => {
-    (window as any).__NEXT_BROWSER_REACT_TIMING__ = [];
-  });
-
-  // Full page navigation — triggers hydration.
-  await page.goto(targetUrl, { waitUntil: "load" });
-
-  // Wait for passive effects and late commits to flush.
-  await new Promise((r) => setTimeout(r, 3000));
-
-  // Collect captured timing entries.
-  const entries = await page.evaluate(() => {
-    return (window as any).__NEXT_BROWSER_REACT_TIMING__ ?? [];
-  }) as Array<{
-    label: string;
-    startTime: number;
-    endTime: number;
-    track: string;
-    trackGroup: string;
-    color: string;
-  }>;
-
-  // Separate scheduler-level phases from component-level entries.
-  // Filter out zero-duration track registration entries.
-  const phases = entries.filter((e) => e.trackGroup === "Scheduler ⚛" && e.endTime > e.startTime);
-  const components = entries.filter((e) => e.track === "Components ⚛" && e.endTime > e.startTime);
-
-  // Find hydration phase(s) specifically.
-  const hydrationPhases = phases.filter((e) => e.label === "Hydrated");
-
-  // Hydrated components use tertiary colors in React's performance track.
-  const hydratedComponents = components.filter((e) =>
-    e.color?.startsWith("tertiary"),
-  );
-
-  // Compute overall hydration render window.
-  let hydrationStart = Infinity;
-  let hydrationEnd = 0;
-  for (const p of hydrationPhases) {
-    if (p.startTime < hydrationStart) hydrationStart = p.startTime;
-    if (p.endTime > hydrationEnd) hydrationEnd = p.endTime;
-  }
-
-  return {
-    url: targetUrl,
-    hydration: hydrationPhases.length > 0
-      ? {
-          startTime: Math.round(hydrationStart * 100) / 100,
-          endTime: Math.round(hydrationEnd * 100) / 100,
-          duration: Math.round((hydrationEnd - hydrationStart) * 100) / 100,
-        }
-      : null,
-    phases: phases.map((p) => ({
-      label: p.label,
-      startTime: Math.round(p.startTime * 100) / 100,
-      endTime: Math.round(p.endTime * 100) / 100,
-      duration: Math.round((p.endTime - p.startTime) * 100) / 100,
-    })),
-    hydratedComponents: hydratedComponents
-      .map((c) => ({
-        name: c.label,
-        startTime: Math.round(c.startTime * 100) / 100,
-        endTime: Math.round(c.endTime * 100) / 100,
-        duration: Math.round((c.endTime - c.startTime) * 100) / 100,
-      }))
-      .sort((a, b) => b.duration - a.duration),
-    totalEntries: entries.length,
-  };
 }
 
 /** Evaluate arbitrary JavaScript in the page context. */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,16 +59,56 @@ if (cmd === "reload") {
   exit(res, res.ok ? `reloaded → ${res.data}` : "");
 }
 
-if (cmd === "capture-goto") {
-  const res = await send("capture-goto", arg ? { url: arg } : {});
+if (cmd === "perf") {
+  const res = await send("perf", arg ? { url: arg } : {});
   if (!res.ok) exit(res, "");
-  const data = res.data as { dir: string; frames: number };
-  exit(
-    res,
-    `${data.frames} frames → ${data.dir}\n` +
-      "\n" +
-      "frame-0000.png is the PPR shell. Remaining frames capture hydration → data.",
-  );
+  const d = res.data as {
+    url: string;
+    ttfb: number | null;
+    lcp: { startTime: number; size: number; element: string | null; url: string | null } | null;
+    cls: { score: number; entries: { value: number; startTime: number }[] };
+    hydration: { startTime: number; endTime: number; duration: number } | null;
+    phases: { label: string; startTime: number; endTime: number; duration: number }[];
+    hydratedComponents: { name: string; startTime: number; endTime: number; duration: number }[];
+  };
+  const lines: string[] = [`# Page Load Profile — ${d.url}`, ""];
+
+  // Core Web Vitals
+  lines.push("## Core Web Vitals");
+  const ttfbStr = d.ttfb != null ? `${d.ttfb}ms` : "—";
+  lines.push(`  TTFB              ${ttfbStr.padStart(10)}`);
+  if (d.lcp) {
+    const lcpLabel = d.lcp.element ? ` (${d.lcp.element}${d.lcp.url ? `: ${d.lcp.url.slice(0, 60)}` : ""})` : "";
+    lines.push(`  LCP               ${String(d.lcp.startTime + "ms").padStart(10)}${lcpLabel}`);
+  } else {
+    lines.push(`  LCP                        —`);
+  }
+  lines.push(`  CLS               ${String(d.cls.score).padStart(10)}`);
+  lines.push("");
+
+  // React Hydration
+  if (d.hydration) {
+    lines.push(`## React Hydration — ${d.hydration.duration}ms (${d.hydration.startTime}ms → ${d.hydration.endTime}ms)`);
+  } else {
+    lines.push("## React Hydration — no data (requires profiling build)");
+  }
+  if (d.phases.length > 0) {
+    for (const p of d.phases) {
+      lines.push(`  ${p.label.padEnd(28)} ${String(p.duration + "ms").padStart(10)}  (${p.startTime} → ${p.endTime})`);
+    }
+    lines.push("");
+  }
+  if (d.hydratedComponents.length > 0) {
+    lines.push(`## Hydrated components (${d.hydratedComponents.length} total, sorted by duration)`);
+    const top = d.hydratedComponents.slice(0, 30);
+    for (const c of top) {
+      lines.push(`  ${c.name.padEnd(40)} ${String(c.duration + "ms").padStart(10)}`);
+    }
+    if (d.hydratedComponents.length > 30) {
+      lines.push(`  ... and ${d.hydratedComponents.length - 30} more`);
+    }
+  }
+  exit(res, lines.join("\n"));
 }
 
 if (cmd === "restart-server") {
@@ -155,45 +195,6 @@ if (cmd === "logs") {
 if (cmd === "action") {
   const res = await send("mcp", { tool: "get_server_action_by_id", args: { actionId: arg } });
   exit(res, res.ok ? json(res.data) : "");
-}
-
-if (cmd === "hydration") {
-  const res = await send("hydration", arg ? { url: arg } : {});
-  if (!res.ok) exit(res, "");
-  const d = res.data as {
-    url: string;
-    hydration: { startTime: number; endTime: number; duration: number } | null;
-    phases: { label: string; startTime: number; endTime: number; duration: number }[];
-    hydratedComponents: { name: string; startTime: number; endTime: number; duration: number }[];
-    totalEntries: number;
-  };
-  const lines: string[] = [`# React Hydration Timing — ${d.url}`];
-  if (d.hydration) {
-    lines.push(
-      `# Hydration render: ${d.hydration.duration}ms (${d.hydration.startTime}ms → ${d.hydration.endTime}ms)`,
-    );
-  } else {
-    lines.push("# No hydration phase detected (requires React profiling build)");
-  }
-  lines.push("");
-  if (d.phases.length > 0) {
-    lines.push("## Scheduler phases");
-    for (const p of d.phases) {
-      lines.push(`  ${p.label.padEnd(24)} ${String(p.duration).padStart(8)}ms  (${p.startTime} → ${p.endTime})`);
-    }
-    lines.push("");
-  }
-  if (d.hydratedComponents.length > 0) {
-    lines.push(`## Hydrated components (${d.hydratedComponents.length} total, sorted by duration)`);
-    const top = d.hydratedComponents.slice(0, 30);
-    for (const c of top) {
-      lines.push(`  ${c.name.padEnd(40)} ${String(c.duration).padStart(8)}ms`);
-    }
-    if (d.hydratedComponents.length > 30) {
-      lines.push(`  ... and ${d.hydratedComponents.length - 30} more`);
-    }
-  }
-  exit(res, lines.join("\n"));
 }
 
 if (cmd === "network") {
@@ -295,7 +296,7 @@ function printUsage() {
       "  push [path]        client-side navigation (interactive picker if no path)\n" +
       "  back               go back in history\n" +
       "  reload             reload current page\n" +
-      "  capture-goto [url]   capture loading sequence (PPR shell → hydration → data)\n" +
+      "  perf [url]         profile page load (CWVs + React hydration timing)\n" +
       "  restart-server     restart the Next.js dev server (clears fs cache)\n" +
       "\n" +
       "  ppr lock           enter PPR instant-navigation mode\n" +
@@ -310,7 +311,6 @@ function printUsage() {
       "\n" +
       "  errors             show build/runtime errors\n" +
       "  logs               show recent dev server log output\n" +
-      "  hydration [url]    measure React hydration timing (requires profiling build)\n" +
       "  network [idx]      list network requests, or inspect one\n" +
       "\n" +
       "  page               show current page segments and router info\n" +

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -78,8 +78,8 @@ async function run(cmd: Cmd) {
     const data = await browser.reload();
     return { ok: true, data };
   }
-  if (cmd.action === "capture-goto") {
-    const data = await browser.captureGoto(cmd.url as string | undefined);
+  if (cmd.action === "perf") {
+    const data = await browser.perf(cmd.url as string | undefined);
     return { ok: true, data };
   }
   if (cmd.action === "restart") {
@@ -124,10 +124,6 @@ async function run(cmd: Cmd) {
   }
   if (cmd.action === "mcp") {
     const data = await browser.mcp(cmd.tool!, cmd.args);
-    return { ok: true, data };
-  }
-  if (cmd.action === "hydration") {
-    const data = await browser.hydration(cmd.url as string | undefined);
     return { ok: true, data };
   }
   if (cmd.action === "network") {

--- a/src/suspense.ts
+++ b/src/suspense.ts
@@ -269,65 +269,46 @@ export function formatReport(report: AnalysisReport): string {
       lines.push("");
     }
 
-    lines.push("## Dynamic holes (suspended in shell)");
-    for (const hole of report.holes) {
-      const name = hole.name ?? "(unnamed)";
-      const src = hole.source ? `${hole.source[0]}:${hole.source[1]}:${hole.source[2]}` : null;
-      lines.push(`  ${name}${src ? ` at ${src}` : ""}`);
-      if (hole.renderedBy.length > 0) {
-        lines.push(`    rendered by: ${hole.renderedBy.map((o) => {
-          const env = o.env ? ` [${o.env}]` : "";
-          const src = o.source ? ` at ${o.source[0]}:${o.source[1]}` : "";
-          return `${o.name}${env}${src}`;
-        }).join(" > ")}`);
-      }
-      if (hole.environments.length > 0) lines.push(`    environments: ${hole.environments.join(", ")}`);
-      if (hole.primaryBlocker) {
-        lines.push(
-          `    primary blocker: ${hole.primaryBlocker.name} ` +
-            `(${hole.primaryBlocker.kind}, actionability ${labelActionability(hole.primaryBlocker.actionability)})`,
-        );
-        if (hole.fallbackSource.path) {
-          lines.push(
-            `    fallback source: ${hole.fallbackSource.path} ` +
-              `(${hole.fallbackSource.confidence} confidence)`,
-          );
+    // Detail section — only shows info NOT already in the Quick Reference table:
+    // owner chains, environment tags, secondary blockers, and stack frames.
+    const holesWithDetail = report.holes.filter(
+      (h) => h.renderedBy.length > 0 || h.environments.length > 0 || h.blockers.length > 1 || h.unknownSuspenders,
+    );
+    if (holesWithDetail.length > 0) {
+      lines.push("## Detail");
+      for (const hole of holesWithDetail) {
+        const name = hole.name ?? "(unnamed)";
+        lines.push(`  ${name}`);
+        if (hole.renderedBy.length > 0) {
+          lines.push(`    rendered by: ${hole.renderedBy.map((o) => {
+            const env = o.env ? ` [${o.env}]` : "";
+            const src = o.source ? ` at ${o.source[0]}:${o.source[1]}` : "";
+            return `${o.name}${env}${src}`;
+          }).join(" > ")}`);
         }
-        if (hole.primaryBlocker.sourceFrame) {
-          lines.push(
-            `      source: ${hole.primaryBlocker.sourceFrame[0] || "(anonymous)"} ` +
-              `${hole.primaryBlocker.sourceFrame[1]}:${hole.primaryBlocker.sourceFrame[2]}`,
-          );
-        }
-        lines.push(`      next step: ${hole.recommendation}`);
-      }
-      if (hole.blockers.length > 0) {
-        lines.push("    blocked by:");
-        for (const blocker of hole.blockers) {
-          const dur = hole.primaryBlocker?.name === blocker.name ? " [primary]" : "";
-          const env = blocker.env ? ` [${blocker.env}]` : "";
-          const owner = blocker.ownerName ? ` initiated by <${blocker.ownerName}>` : "";
-          const awaiter = blocker.awaiterName ? ` awaited in <${blocker.awaiterName}>` : "";
-          lines.push(`      - ${blocker.name}: ${blocker.description || "(no description)"}${env}${dur}${owner}${awaiter}`);
-          if (blocker.ownerFrame) {
-            const [fn, file, line] = blocker.ownerFrame;
-            lines.push(`          owner: ${fn || "(anonymous)"} ${file}:${line}`);
-          }
-          if (blocker.awaiterFrame && !blocker.ownerFrame) {
-            const [fn, file, line] = blocker.awaiterFrame;
-            lines.push(`          awaiter: ${fn || "(anonymous)"} ${file}:${line}`);
-          }
-          if (blocker.ownerFrame && hole.primaryBlocker?.name === blocker.name) {
-            for (const [fn, file, line] of [blocker.ownerFrame].slice(0, 3)) {
-              lines.push(`          at ${fn || "(anonymous)"} ${file}:${line}`);
+        if (hole.environments.length > 0) lines.push(`    environments: ${hole.environments.join(", ")}`);
+        if (hole.blockers.length > 1) {
+          lines.push("    secondary blockers:");
+          for (const blocker of hole.blockers.slice(1)) {
+            const env = blocker.env ? ` [${blocker.env}]` : "";
+            const owner = blocker.ownerName ? ` initiated by <${blocker.ownerName}>` : "";
+            const awaiter = blocker.awaiterName ? ` awaited in <${blocker.awaiterName}>` : "";
+            lines.push(`      - ${blocker.name}: ${blocker.description || "(no description)"}${env}${owner}${awaiter}`);
+            if (blocker.ownerFrame) {
+              const [fn, file, line] = blocker.ownerFrame;
+              lines.push(`          owner: ${fn || "(anonymous)"} ${file}:${line}`);
+            } else if (blocker.awaiterFrame) {
+              const [fn, file, line] = blocker.awaiterFrame;
+              lines.push(`          awaiter: ${fn || "(anonymous)"} ${file}:${line}`);
             }
           }
         }
-      } else if (hole.unknownSuspenders) {
-        lines.push(`    suspenders unknown: ${hole.unknownSuspenders}`);
+        if (hole.unknownSuspenders) {
+          lines.push(`    suspenders unknown: ${hole.unknownSuspenders}`);
+        }
       }
+      lines.push("");
     }
-    lines.push("");
   }
 
   if (report.statics.length > 0) {


### PR DESCRIPTION
## Summary

- Intercepts `console.timeStamp` calls from React's profiling build to capture precise hydration timing data
- Adds `next-browser hydration [url]` command that navigates to a page and reports:
  - Overall hydration render duration (from React's `performance.now()`-based timestamps)
  - All scheduler phases (Hydrated, Commit, Remaining Effects, etc.)
  - Per-component hydration durations sorted by cost
- Requires React profiling build (`next dev`) — production builds strip `console.timeStamp` calls

## How it works

React's reconciler (behind `enableProfilerTimer`) calls `console.timeStamp(label, startTime, endTime, track, trackGroup, color)` where timestamps come from `Scheduler.unstable_now()` = `performance.now()`. The "Hydrated" label on the "Scheduler ⚛" track marks the render phase of hydration. Components hydrated in that pass use tertiary colors on the "Components ⚛" track.

We install a `console.timeStamp` interceptor via Playwright's `addInitScript` (runs before any page JS), capture all entries into `window.__NEXT_BROWSER_REACT_TIMING__`, then filter and structure them after navigation completes.

## Example output

```
# React Hydration Timing — http://localhost:3000/dashboard
# Hydration render: 65.5ms (466.2ms → 531.7ms)

## Scheduler phases
  Hydrated                     65.5ms  (466.2 → 531.7)
  Commit                        2.0ms  (531.7 → 533.7)
  Waiting for Paint             3.0ms  (533.7 → 536.7)
  Remaining Effects             4.1ms  (536.7 → 540.8)

## Hydrated components (42 total, sorted by duration)
  DeploymentsProvider                       8.3ms
  NavigationProvider                        5.1ms
  ...
```

## Test plan

- [ ] Run `next-browser hydration` against a local Next.js dev server and verify timing data is returned
- [ ] Run against a production site and verify the "No hydration phase detected" message appears
- [ ] Verify existing commands (`tree`, `capture-goto`, `ppr lock/unlock`) still work — the `console.timeStamp` interceptor passes through to the original