### PR TITLE
[eval] Accept --file and stdin to avoid shell quoting failures

### DIFF
--- a/.changeset/eval-file-stdin.md
+++ b/.changeset/eval-file-stdin.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next-browser": minor
+---
+
+Add `--file` and stdin (`-`) modes to `eval` command to avoid shell quoting failures

--- a/SKILL.md
+++ b/SKILL.md
@@ -302,9 +302,11 @@ $ next-browser screenshot
 Don't narrate what the screenshot shows — the user can see the browser.
 State your conclusion or next action, not a description of the page.
 
-### `eval <script>`
+### `eval <script>` · `eval --file <path>` · `eval -`
 
 Run JS in page context. Returns the result as JSON.
+
+**For simple one-liners**, pass the script inline:
 
 ```
 $ next-browser eval 'document.title'
@@ -312,15 +314,25 @@ $ next-browser eval 'document.title'
 
 $ next-browser eval 'document.querySelectorAll("a[href]").length'
 47
-
-$ next-browser eval 'document.querySelector("nextjs-portal")?.shadowRoot?.querySelector("[data-nextjs-dialog]")?.textContent'
-"Runtime ErrorCall Stack 6..."
 ```
 
-Use this to read the Next.js error overlay (it's in shadow DOM).
+**For multi-line or quote-heavy scripts**, use `--file` (or `-f`) to avoid
+shell quoting issues entirely:
 
-For multi-statement code that uses `return`, wrap in an IIFE:
-`next-browser eval '(() => { const els = ...; return els.length; })()'`
+```bash
+cat > /tmp/nb-eval.js << 'SCRIPT'
+(() => {
+  // your JS here — no shell escaping needed
+  return someResult;
+})()
+SCRIPT
+next-browser eval --file /tmp/nb-eval.js
+```
+
+You can also pipe via stdin: `echo 'document.title' | next-browser eval -`
+
+Use this to read the Next.js error overlay (it's in shadow DOM):
+`next-browser eval 'document.querySelector("nextjs-portal")?.shadowRoot?.querySelector("[data-nextjs-dialog]")?.textContent'`
 
 `eval` runs synchronously in page context — top-level `await` is not
 supported. Wrap in an async IIFE if you need to await:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -115,11 +115,27 @@ if (cmd === "screenshot") {
 }
 
 if (cmd === "eval") {
-  if (!arg) {
-    console.error("usage: next-browser eval <script>");
+  let script: string | undefined;
+  if (arg === "--file" || arg === "-f") {
+    const filePath = args[2];
+    if (!filePath) {
+      console.error("usage: next-browser eval --file <path>");
+      process.exit(1);
+    }
+    script = readFileSync(filePath, "utf-8");
+  } else if (arg === "-") {
+    // Read from stdin
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) chunks.push(chunk);
+    script = Buffer.concat(chunks).toString("utf-8");
+  } else {
+    script = arg;
+  }
+  if (!script) {
+    console.error("usage: next-browser eval <script>\n       next-browser eval --file <path>\n       echo 'script' | next-browser eval -");
     process.exit(1);
   }
-  const res = await send("eval", { script: arg });
+  const res = await send("eval", { script });
   exit(res, res.ok ? json(res.data) : "");
 }
 
@@ -268,6 +284,8 @@ function printUsage() {
       "  viewport [WxH]     show or set viewport size (e.g. 1280x720)\n" +
       "  screenshot         save full-page screenshot to tmp file\n" +
       "  eval <script>      evaluate JS in page context\n" +
+      "  eval --file <path>  evaluate JS from a file\n" +
+      "  eval -              evaluate JS from stdin\n" +
       "\n" +
       "  errors             show build/runtime errors\n" +
       "  logs               show recent dev server log output\n" +


### PR DESCRIPTION
Agents using `next-browser eval` with inline JS consistently fail 2-3 times on shell quoting before discovering the `cat > /tmp/file && eval "$(cat /tmp/file)"` workaround. The quoting problem is inherent to passing complex JS through a shell — nested quotes, template literals, and special characters all break.

This adds `--file <path>` (or `-f`) and stdin (`-`) modes to `eval`, so agents can write their script to a temp file and pass it directly without any shell escaping. The inline form still works for simple one-liners like `document.title`.

SKILL.md updated to lead with `--file` as the recommended approach for multi-line scripts.