### PR TITLE
Use named pipes on Windows instead of Unix domain sockets

### DIFF
--- a/.changeset/windows-named-pipes.md
+++ b/.changeset/windows-named-pipes.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next-browser": patch
+---
+
+Use named pipes on Windows instead of Unix domain sockets to fix daemon startup failure

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -4,5 +4,8 @@ import { join } from "node:path";
 const dir = join(homedir(), ".next-browser");
 
 export const socketDir = dir;
-export const socketPath = join(dir, "default.sock");
+export const socketPath =
+  process.platform === "win32"
+    ? "//./pipe/next-browser-default"
+    : join(dir, "default.sock");
 export const pidFile = join(dir, "default.pid");


### PR DESCRIPTION
`node:net` Unix domain sockets are not supported on Windows — `server.listen()` with a `.sock` file path returns `EACCES` regardless of the directory or permissions, which causes the daemon to fail to start.

Windows supports named pipes via `//./pipe/<name>`. This switches `socketPath` in `src/paths.ts` to use a named pipe on `win32` while keeping the existing Unix domain socket path on macOS and Linux.

Fixes https://github.com/vercel-labs/next-browser/issues/3.