### PR TITLE
Add snapshot, click, fill commands and ref-based element targeting

### DIFF
--- a/.changeset/snapshot-click-fill.md
+++ b/.changeset/snapshot-click-fill.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next-browser": minor
+---
+
+Add `snapshot`, `click`, and `fill` commands for page interaction via accessibility tree refs

--- a/SKILL.md
+++ b/SKILL.md
@@ -327,11 +327,106 @@ $ next-browser screenshot
 Don't narrate what the screenshot shows — the user can see the browser.
 State your conclusion or next action, not a description of the page.
 
-### `eval <script>` · `eval --file <path>` · `eval -`
+**Prefer `snapshot` over `screenshot`** when you need to understand
+what's on the page or decide what to interact with. `snapshot`
+returns structured, semantic data (roles, names, state) that you can act
+on directly — screenshots are pixels you have to interpret. Use
+`screenshot` only when visual layout matters (CSS issues, verifying
+appearance, PPR shell inspection).
+
+### `snapshot`
+
+Snapshot the page's accessibility tree — the semantic structure a screen
+reader sees — with `[ref=eN]` markers on every interactive element. Use
+this to discover what's on the page before clicking.
+
+```
+$ next-browser snapshot
+- navigation "Main"
+  - link "Home" [ref=e0]
+  - link "Dashboard" [ref=e1]
+- main
+  - heading "Settings"
+  - tablist
+    - tab "General" [ref=e2] (selected)
+    - tab "Security" [ref=e3]
+  - region "Profile"
+    - textbox "Username" [ref=e4]
+    - button "Save" [ref=e5]
+```
+
+The tree shows headings, landmarks (`navigation`, `main`, `region`), and
+state (`selected`, `checked`, `expanded`, `disabled`) so you understand
+page layout, not just a flat element list.
+
+Refs are ephemeral — they reset on every `snapshot` call and are
+invalid after navigation. Re-run `snapshot` after `goto`/`push`.
+
+### `click <ref|text|selector>`
+
+Click an element using real pointer events (`pointerdown → mousedown →
+pointerup → mouseup → click`). This works with libraries that ignore
+synthetic `.click()` (Radix UI, Headless UI, etc.).
+
+Three ways to target:
+
+| Input            | Example                | How it resolves                       |
+| ---              | ---                    | ---                                   |
+| Ref from tree    | `click e3`             | Looks up role+name from last snapshot |
+| Plain text       | `click "Security"`     | Playwright `text=Security` selector   |
+| Playwright selector | `click "#submit-btn"` | Used as-is (CSS, `role=`, etc.)    |
+
+**Recommended workflow:** run `snapshot` first, then `click eN`.
+Refs are the most reliable — they resolve via ARIA role+name, so they
+work even when elements have no stable CSS selector.
+
+```
+$ next-browser snapshot
+- tablist
+  - tab "General" [ref=e0] (selected)
+  - tab "Security" [ref=e1]
+$ next-browser click e1
+clicked
+$ next-browser snapshot
+- tablist
+  - tab "General" [ref=e0]
+  - tab "Security" [ref=e1] (selected)
+```
+
+### `fill <ref|selector> <value>`
+
+Fill a text input or textarea. Clears existing content, then types the
+new value — dispatches all the events React and other frameworks expect.
+
+```
+$ next-browser snapshot
+- textbox "Username" [ref=e4]
+$ next-browser fill e4 "judegao"
+filled
+```
+
+### `eval [ref] <script>` · `eval [ref] --file <path>` · `eval -`
 
 Run JS in page context. Returns the result as JSON.
 
-**For simple one-liners**, pass the script inline:
+**With a ref**, the script receives the DOM element as its argument —
+useful for inspecting a snapshot node or bridging to React internals:
+
+```
+$ next-browser eval e0 'el => el.tagName'
+"BUTTON"
+
+$ next-browser eval e0 'el => {
+  const key = Object.keys(el).find(k => k.startsWith("__reactFiber$"));
+  if (!key) return null;
+  let fiber = el[key];
+  while (fiber && typeof fiber.type !== "function") fiber = fiber.return;
+  return fiber?.type?.displayName || fiber?.type?.name || null;
+}'
+"LoginButton"
+```
+
+**For simple one-liners** (no ref), pass the script inline:
 
 ```
 $ next-browser eval 'document.title'

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -568,9 +568,185 @@ async function hideDevOverlay() {
   }).catch(() => {});
 }
 
-/** Evaluate arbitrary JavaScript in the page context. */
-export async function evaluate(script: string) {
+// ── Ref map for interactive elements ──────────────────────────────────
+
+const INTERACTIVE_ROLES = new Set([
+  "button", "link", "textbox", "checkbox", "radio", "combobox", "listbox",
+  "menuitem", "menuitemcheckbox", "menuitemradio", "option", "searchbox",
+  "slider", "spinbutton", "switch", "tab", "treeitem",
+]);
+
+type Ref = { role: string; name: string; nth?: number };
+let refMap: Ref[] = [];
+
+type CDPAXNode = {
+  nodeId: string;
+  role: { type: string; value: string };
+  name?: { type: string; value: string };
+  properties?: { name: string; value: { type: string; value: unknown } }[];
+  childIds?: string[];
+  backendDOMNodeId?: number;
+};
+
+/**
+ * Snapshot the accessibility tree via CDP and return a text representation
+ * with [ref=e0], [ref=e1] … markers on interactive elements.
+ * Stores a ref map so that `click("e3")` can resolve back to role+name.
+ */
+export async function snapshot() {
   if (!page) throw new Error("browser not open");
+
+  const cdp = await page.context().newCDPSession(page);
+  try {
+    const { nodes } = (await cdp.send("Accessibility.getFullAXTree" as never)) as {
+      nodes: CDPAXNode[];
+    };
+
+    // Index nodes by ID
+    const byId = new Map<string, CDPAXNode>();
+    for (const n of nodes) byId.set(n.nodeId, n);
+
+    refMap = [];
+    const roleNameCount = new Map<string, number>();
+    const lines: string[] = [];
+
+    function walk(node: CDPAXNode, depth: number) {
+      const role = node.role?.value || "unknown";
+      const name = (node.name?.value || "").trim().slice(0, 80);
+      const isInteractive = INTERACTIVE_ROLES.has(role);
+
+      // Read properties into a map
+      const propMap = new Map<string, unknown>();
+      for (const p of node.properties || []) propMap.set(p.name, p.value.value);
+
+      const ignored = propMap.get("hidden") === true;
+      if (ignored) return;
+
+      // Always skip leaf text nodes — parent already carries the text
+      if (role === "InlineTextBox" || role === "StaticText" || role === "LineBreak") return;
+
+      // Skip generic/none wrappers with no name — just recurse children
+      const SKIP_ROLES = new Set(["none", "generic", "GenericContainer"]);
+      if (SKIP_ROLES.has(role) && !name) {
+        for (const id of node.childIds || []) {
+          const child = byId.get(id);
+          if (child) walk(child, depth);
+        }
+        return;
+      }
+
+      // Skip root WebArea — just recurse
+      if (role === "WebArea" || role === "RootWebArea") {
+        for (const id of node.childIds || []) {
+          const child = byId.get(id);
+          if (child) walk(child, depth);
+        }
+        return;
+      }
+
+      const indent = "  ".repeat(depth);
+      let line = `${indent}- ${role}`;
+      if (name) line += ` "${name}"`;
+
+      const disabled = propMap.get("disabled") === true;
+
+      if (isInteractive && !disabled) {
+        const key = `${role}::${name}`;
+        const count = roleNameCount.get(key) || 0;
+        roleNameCount.set(key, count + 1);
+
+        const ref: Ref = { role, name };
+        if (count > 0) ref.nth = count;
+        const idx = refMap.length;
+        refMap.push(ref);
+        line += ` [ref=e${idx}]`;
+      }
+
+      // Append state properties
+      const tags: string[] = [];
+      if (propMap.get("checked") === "true" || propMap.get("checked") === true) tags.push("checked");
+      if (propMap.get("checked") === "mixed") tags.push("mixed");
+      if (disabled) tags.push("disabled");
+      if (propMap.get("expanded") === true) tags.push("expanded");
+      if (propMap.get("expanded") === false) tags.push("collapsed");
+      if (propMap.get("selected") === true) tags.push("selected");
+      if (tags.length) line += ` (${tags.join(", ")})`;
+
+      lines.push(line);
+      for (const id of node.childIds || []) {
+        const child = byId.get(id);
+        if (child) walk(child, depth + 1);
+      }
+    }
+
+    // Start from the root (first node)
+    if (nodes.length) walk(nodes[0], 0);
+    return lines.join("\n");
+  } finally {
+    await cdp.detach();
+  }
+}
+
+/** Resolve a ref (e.g. "e3") or selector string to a Playwright Locator. */
+function resolveLocator(selectorOrRef: string) {
+  if (!page) throw new Error("browser not open");
+
+  const refMatch = selectorOrRef.match(/^e(\d+)$/);
+  if (refMatch) {
+    const idx = Number(refMatch[1]);
+    const ref = refMap[idx];
+    if (!ref) throw new Error(`ref e${idx} not found — run snapshot first`);
+    const locator = page.getByRole(ref.role as Parameters<Page["getByRole"]>[0], {
+      name: ref.name,
+      exact: true,
+    });
+    return ref.nth != null ? locator.nth(ref.nth) : locator;
+  }
+
+  const hasPrefix = /^(css=|text=|role=|#|\[|\.|\w+\s*>)/.test(selectorOrRef);
+  return page.locator(hasPrefix ? selectorOrRef : `text=${selectorOrRef}`);
+}
+
+/**
+ * Click an element using real pointer events.
+ * Accepts: "e3" (ref from snapshot), plain text, or Playwright selectors.
+ */
+export async function click(selectorOrRef: string) {
+  if (!page) throw new Error("browser not open");
+  await resolveLocator(selectorOrRef).click();
+}
+
+/**
+ * Fill a text input/textarea. Clears existing value, then types the new one.
+ * Accepts: "e3" (ref from snapshot), or a selector.
+ */
+export async function fill(selectorOrRef: string, value: string) {
+  if (!page) throw new Error("browser not open");
+  await resolveLocator(selectorOrRef).fill(value);
+}
+
+/**
+ * Evaluate arbitrary JavaScript in the page context.
+ * If ref is provided (e.g. "e3"), the script receives the DOM element as its
+ * first argument: `next-browser eval e3 'el => el.textContent'`
+ */
+export async function evaluate(script: string, ref?: string) {
+  if (!page) throw new Error("browser not open");
+  if (ref) {
+    const locator = resolveLocator(ref);
+    const handle = await locator.elementHandle();
+    if (!handle) throw new Error(`ref ${ref} not found in DOM`);
+    // The script should be an arrow/function that receives the element.
+    // We wrap it so page.evaluate can pass the element handle as an arg.
+    return page.evaluate(
+      ([fn, el]) => {
+        // eslint-disable-next-line no-eval
+        const f = (0, eval)(fn);
+        return f(el);
+      },
+      [script, handle] as const,
+    );
+  }
   return page.evaluate(script);
 }
 
@@ -660,9 +836,12 @@ async function launch() {
 
   const ctx = await chromium.launchPersistentContext(dir, {
     headless,
-    viewport: { width: 1440, height: 900 },
+    viewport: null,
     // --no-sandbox is required when Chrome runs as root (common in containers/cloud sandboxes)
-    args: headless ? ["--no-sandbox"] : [],
+    args: [
+      ...(headless ? ["--no-sandbox"] : []),
+      "--window-size=1440,900",
+    ],
   });
   await ctx.addInitScript(installHook);
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -154,28 +154,62 @@ if (cmd === "screenshot") {
   exit(res, res.ok ? String(res.data) : "");
 }
 
+if (cmd === "snapshot") {
+  const res = await send("snapshot");
+  exit(res, res.ok ? json(res.data) : "");
+}
+
+if (cmd === "click") {
+  if (!arg) {
+    console.error("usage: next-browser click <ref|text|selector>");
+    process.exit(1);
+  }
+  const res = await send("click", { selector: arg });
+  exit(res, "clicked");
+}
+
+if (cmd === "fill") {
+  const value = args[2];
+  if (!arg || value === undefined) {
+    console.error("usage: next-browser fill <ref|selector> <value>");
+    process.exit(1);
+  }
+  const res = await send("fill", { selector: arg, value });
+  exit(res, "filled");
+}
+
 if (cmd === "eval") {
+  // Check if first arg is a ref (e.g. "e3") — if so, second arg is the script
+  let ref: string | undefined;
+  let scriptArg = arg;
+  let fileArgIdx = 2;
+  if (arg && /^e\d+$/.test(arg)) {
+    ref = arg;
+    scriptArg = args[2];
+    fileArgIdx = 3;
+  }
+
   let script: string | undefined;
-  if (arg === "--file" || arg === "-f") {
-    const filePath = args[2];
+  if (scriptArg === "--file" || scriptArg === "-f") {
+    const filePath = args[fileArgIdx];
     if (!filePath) {
-      console.error("usage: next-browser eval --file <path>");
+      console.error("usage: next-browser eval [ref] --file <path>");
       process.exit(1);
     }
     script = readFileSync(filePath, "utf-8");
-  } else if (arg === "-") {
+  } else if (scriptArg === "-") {
     // Read from stdin
     const chunks: Buffer[] = [];
     for await (const chunk of process.stdin) chunks.push(chunk);
     script = Buffer.concat(chunks).toString("utf-8");
   } else {
-    script = arg;
+    script = scriptArg;
   }
   if (!script) {
-    console.error("usage: next-browser eval <script>\n       next-browser eval --file <path>\n       echo 'script' | next-browser eval -");
+    console.error("usage: next-browser eval [ref] <script>\n       next-browser eval [ref] --file <path>\n       echo 'script' | next-browser eval -");
     process.exit(1);
   }
-  const res = await send("eval", { script });
+  const res = await send("eval", { script, ...(ref ? { selector: ref } : {}) });
   exit(res, res.ok ? json(res.data) : "");
 }
 
@@ -323,9 +357,12 @@ function printUsage() {
       "\n" +
       "  viewport [WxH]     show or set viewport size (e.g. 1280x720)\n" +
       "  screenshot         save full-page screenshot to tmp file\n" +
-      "  eval <script>      evaluate JS in page context\n" +
-      "  eval --file <path>  evaluate JS from a file\n" +
-      "  eval -              evaluate JS from stdin\n" +
+      "  snapshot           accessibility tree with interactive refs\n" +
+      "  click <ref|sel>    click an element (real pointer events)\n" +
+      "  fill <ref|sel> <v> fill a text input\n" +
+      "  eval [ref] <script> evaluate JS in page context\n" +
+      "  eval --file <path> evaluate JS from a file\n" +
+      "  eval -             evaluate JS from stdin\n" +
       "\n" +
       "  errors             show build/runtime errors\n" +
       "  logs               show recent dev server log output\n" +

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -50,6 +50,8 @@ type Cmd = {
   tool?: string;
   args?: Record<string, unknown>;
   script?: string;
+  selector?: string;
+  value?: string;
   idx?: number;
   cookies?: { name: string; value: string }[];
   domain?: string;
@@ -118,8 +120,20 @@ async function run(cmd: Cmd) {
     const data = await browser.node(cmd.nodeId!);
     return { ok: true, data };
   }
+  if (cmd.action === "snapshot") {
+    const data = await browser.snapshot();
+    return { ok: true, data };
+  }
+  if (cmd.action === "click") {
+    await browser.click(cmd.selector!);
+    return { ok: true };
+  }
+  if (cmd.action === "fill") {
+    await browser.fill(cmd.selector!, cmd.value!);
+    return { ok: true };
+  }
   if (cmd.action === "eval") {
-    const data = await browser.evaluate(cmd.script!);
+    const data = await browser.evaluate(cmd.script!, cmd.selector);
     return { ok: true, data };
   }
   if (cmd.action === "mcp") {


### PR DESCRIPTION
Agents had no way to discover interactive elements or click them with real pointer events. Libraries like Radix UI ignore synthetic `.click()` because they listen for `pointerdown`/`pointerup` — the full event sequence a real user produces.

This adds four capabilities:

`snapshot` uses CDP `Accessibility.getFullAXTree` to render the page's accessibility tree as indented text, with `[ref=eN]` markers on interactive elements (buttons, links, tabs, textboxes, etc.). The tree includes semantic structure — landmarks, headings, regions, and state like `selected`, `checked`, `expanded` — so agents understand page layout, not just a flat element list. Refs are stored in a module-level map keyed by role+name.

`click` and `fill` accept a ref (`e3`), plain text (`"Settings"`), or a Playwright selector (`#id`). Refs resolve via `page.getByRole()` with the stored role+name, which dispatches the full pointer event sequence. Duplicate role+name pairs are tracked with an `nth` counter for disambiguation.

`eval` now accepts an optional ref as its first argument (`eval e3 'el => el.tagName'`). The ref resolves to an `ElementHandle`, and the script runs with the DOM element as its argument — useful for inspecting React fibers or computed styles on a specific snapshot node.

Also includes a viewport launch change (`viewport: null` + `--window-size=1440,900`) so the browser window matches desktop size without constraining the viewport.