### PR TITLE
Replace ssr-goto with ssr lock/unlock for persistent SSR inspection

### DIFF
--- a/.changeset/ssr-lock-unlock.md
+++ b/.changeset/ssr-lock-unlock.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next-browser": minor
+---
+
+Replace `ssr-goto` with `ssr lock` / `ssr unlock` for persistent SSR inspection across navigations. Auto-open browser on `goto` when not already open. Make lock commands idempotent.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Requires Node >= 20.
 | Command            | Description                                               |
 | ------------------ | --------------------------------------------------------- |
 | `goto <url>`       | Full-page navigation (new document load)                  |
-| `ssr-goto <url>`   | Navigate blocking external scripts (inspect SSR shell)    |
+| `ssr lock`         | Block external scripts on all navigations (SSR-only mode) |
+| `ssr unlock`       | Re-enable external scripts                                |
 | `push [path]`      | Client-side navigation (interactive picker if no path)    |
 | `back`             | Go back in history                                        |
 | `reload`           | Reload current page                                       |

--- a/SKILL.md
+++ b/SKILL.md
@@ -113,22 +113,28 @@ Go back one page in browser history.
 
 Reload the current page from the server.
 
-### `ssr-goto <url>`
+### `ssr lock`
 
-See exactly what the server sent before any client-side JavaScript runs.
-Useful for verifying SSR content, checking what search engines and social
-crawlers see, debugging hydration mismatches, and confirming that data
-appears in the initial HTML rather than being fetched client-side.
-
-The page renders without hydration — no React, no client-side routing,
-no fetch calls. What you see is the raw server output plus CSS.
+Block external scripts on all subsequent navigations. While locked, every
+`goto`, `push`, `back`, and `reload` shows the raw server-rendered HTML
+without React hydration or client-side JavaScript — what search engines
+and social crawlers see.
 
 ```
-$ next-browser ssr-goto http://localhost:3000/dashboard
-→ http://localhost:3000/dashboard (external scripts blocked)
+$ next-browser ssr lock
+ssr locked — external scripts blocked on all navigations
 ```
 
-Use `goto` or `reload` afterward to restore normal behavior.
+### `ssr unlock`
+
+Re-enable external scripts. The next navigation will load normally with
+full hydration.
+
+```
+$ next-browser ssr unlock
+ssr unlocked — external scripts re-enabled
+```
+
 
 ### `perf [url]`
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -37,6 +37,19 @@ let context: BrowserContext | null = null;
 let page: Page | null = null;
 let profileDirPath: string | null = null;
 let initialOrigin: string | null = null;
+let ssrLocked = false;
+
+/** Install or remove the script-blocking route handler based on ssrLocked. */
+async function syncSsrRoutes() {
+  if (!page) return;
+  await page.unrouteAll({ behavior: "wait" });
+  if (ssrLocked) {
+    await page.route("**/*", (route) => {
+      if (route.request().resourceType() === "script") return route.abort();
+      return route.continue();
+    });
+  }
+}
 
 // ── Browser lifecycle ────────────────────────────────────────────────────────
 
@@ -46,11 +59,12 @@ let initialOrigin: string | null = null;
  * reuse the existing context.
  */
 export async function open(url: string | undefined) {
-  if (!context) {
-    context = await launch();
-    page = context.pages()[0] ?? (await context.newPage());
-    net.attach(page);
+  if (context) {
+    await close();
   }
+  context = await launch();
+  page = context.pages()[0] ?? (await context.newPage());
+  net.attach(page);
   if (url) {
     initialOrigin = new URL(url).origin;
     await page!.goto(url, { waitUntil: "domcontentloaded" });
@@ -77,6 +91,7 @@ export async function close() {
   page = null;
   release = null;
   settled = null;
+  ssrLocked = false;
   // Clean up temp profile directory.
   if (profileDirPath) {
     const { rmSync } = await import("node:fs");
@@ -102,7 +117,7 @@ let settled: Promise<void> | null = null;
 /** Enter PPR instant-navigation mode. The cookie is set immediately. */
 export function lock() {
   if (!page) throw new Error("browser not open");
-  if (release) throw new Error("already locked");
+  if (release) return Promise.resolve();
 
   return new Promise<void>((locked) => {
     settled = instant(page!, () => {
@@ -247,6 +262,28 @@ async function waitForDevToolsReconnect(p: Page) {
     if (connected) return;
     await new Promise((r) => setTimeout(r, 200));
   }
+}
+
+// ── SSR lock/unlock ──────────────────────────────────────────────────────────
+//
+// While SSR-locked, every navigation blocks external script resources so the
+// page renders only the server-side HTML shell (no React hydration, no client
+// bundles). Useful for inspecting raw SSR output across multiple navigations.
+
+/** Enter SSR-locked mode. All subsequent navigations block external scripts. */
+export async function ssrLock() {
+  if (!page) throw new Error("browser not open");
+  if (ssrLocked) return;
+  ssrLocked = true;
+  await syncSsrRoutes();
+}
+
+/** Exit SSR-locked mode. Re-enables external scripts. */
+export async function ssrUnlock() {
+  if (!page) throw new Error("browser not open");
+  if (!ssrLocked) return;
+  ssrLocked = false;
+  await syncSsrRoutes();
 }
 
 // ── Navigation ───────────────────────────────────────────────────────────────
@@ -462,32 +499,10 @@ export async function push(path: string) {
 
 /** Full-page navigation (new document load). Resolves relative URLs against the current page. */
 export async function goto(url: string) {
-  if (!page) throw new Error("browser not open");
-  await page.unrouteAll({ behavior: "wait" });
-  const target = new URL(url, page.url()).href;
+  if (!page) await open(undefined);
+  const target = new URL(url, page!.url()).href;
   initialOrigin = new URL(target).origin;
-  await page.goto(target, { waitUntil: "domcontentloaded" });
-  return target;
-}
-
-/**
- * Navigate like goto but block external script resources.
- * The HTML loads and inline <script> blocks still execute, but external JS
- * bundles (React, hydration, etc.) are aborted. Shows the SSR shell.
- */
-export async function ssrGoto(url: string) {
-  if (!page) throw new Error("browser not open");
-  const target = new URL(url, page.url()).href;
-  initialOrigin = new URL(target).origin;
-
-  // Clear any stale route handlers from previous ssr-goto calls.
-  await page.unrouteAll({ behavior: "wait" });
-
-  await page.route("**/*", (route) => {
-    if (route.request().resourceType() === "script") return route.abort();
-    return route.continue();
-  });
-  await page.goto(target, { waitUntil: "domcontentloaded" });
+  await page!.goto(target, { waitUntil: "domcontentloaded" });
   return target;
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -138,9 +138,14 @@ if (cmd === "goto") {
   exit(res, res.ok ? `→ ${res.data}` : "");
 }
 
-if (cmd === "ssr-goto") {
-  const res = await send("ssr-goto", { url: arg });
-  exit(res, res.ok ? `→ ${res.data} (external scripts blocked)` : "");
+if (cmd === "ssr" && arg === "lock") {
+  const res = await send("ssr-lock");
+  exit(res, "ssr locked — external scripts blocked on all navigations");
+}
+
+if (cmd === "ssr" && arg === "unlock") {
+  const res = await send("ssr-unlock");
+  exit(res, "ssr unlocked — external scripts re-enabled");
 }
 
 
@@ -342,7 +347,8 @@ function printUsage() {
       "  close              close browser and daemon\n" +
       "\n" +
       "  goto <url>         full-page navigation (new document load)\n" +
-      "  ssr-goto <url>     goto but block external scripts (SSR shell)\n" +
+      "  ssr lock           block external scripts on all navigations\n" +
+      "  ssr unlock         re-enable external scripts\n" +
       "  push [path]        client-side navigation (interactive picker if no path)\n" +
       "  back               go back in history\n" +
       "  reload             reload current page\n" +

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -104,9 +104,13 @@ async function run(cmd: Cmd) {
     const data = await browser.goto(cmd.url!);
     return { ok: true, data };
   }
-  if (cmd.action === "ssr-goto") {
-    const data = await browser.ssrGoto(cmd.url!);
-    return { ok: true, data };
+  if (cmd.action === "ssr-lock") {
+    await browser.ssrLock();
+    return { ok: true };
+  }
+  if (cmd.action === "ssr-unlock") {
+    await browser.ssrUnlock();
+    return { ok: true };
   }
   if (cmd.action === "back") {
     await browser.back();


### PR DESCRIPTION
The old `ssr-goto` command blocked external scripts for a single navigation, but the route handler was lost on subsequent `goto`, `back`, or `reload` calls. This made it tedious to browse multiple pages in SSR-only mode.

This replaces `ssr-goto` with a lock/unlock pattern modeled after `ppr lock` / `ppr unlock`. A module-level `ssrLocked` flag controls whether Playwright's `page.route()` handler is active. `ssrLock()` installs the handler via `syncSsrRoutes()`, and `ssrUnlock()` removes it. Since Playwright route handlers persist across navigations by default, no per-navigation bookkeeping is needed — `syncSsrRoutes` only runs when toggling the lock.

Also smooths out several friction points: `goto` auto-opens the browser when it isn't already running (instead of erroring), and `ppr lock` / `ssr lock` / `ssr unlock` are now idempotent (no-op when already in the requested state). `open()` now always tears down and re-launches the browser context instead of reusing an existing one, and `close()` resets `ssrLocked`.