### PR TITLE
Add `preview` command for visual feedback and `--full-page` flag for `screenshot`

### DIFF
--- a/.changeset/preview-command.md
+++ b/.changeset/preview-command.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next-browser": minor
+---
+
+Add `preview` command for visual feedback and `--full-page` flag for `screenshot`

--- a/.claude/skills/synthesize-transcript/SKILL.md
+++ b/.claude/skills/synthesize-transcript/SKILL.md
@@ -1,7 +1,7 @@
 ---
 description: >-
   Analyze an agent transcript for generalizable learnings about next-browser
-  CLI usage, then propose SKILL.md updates.
+  CLI usage, then propose SKILL.md updates, feature requests, and bug fixes.
 argument-hint: "<path-to-transcript.jsonl>"
 ---
 
@@ -11,9 +11,12 @@ Read the transcript at:
 
 $ARGUMENTS
 
-Then analyze how the agent used `next-browser` commands. Your goal is to
-find **generalizable learnings** — things that would help any agent using
-this tool — and propose targeted additions to `SKILL.md`.
+Then analyze how the agent used `next-browser` commands. Your goals are to:
+1. Find **generalizable learnings** — things that would help any agent using
+   this tool — and propose targeted additions to `SKILL.md`.
+2. Surface **feature requests and bug fixes** for the CLI itself — gaps in
+   functionality, incorrect behavior, or misleading output that should be
+   fixed in code.
 
 ## Process
 
@@ -34,21 +37,33 @@ this tool — and propose targeted additions to `SKILL.md`.
 
    **Discard** anything that is:
    - A workflow pattern specific to one task (e.g., "copy dirs for before/after")
-   - A workaround for a bug that should be fixed in code instead
    - Advice an agent could derive from reading existing docs
    - Specific to a particular project, page, or debugging scenario
 
-   **Keep** only things that are:
+   **Keep** as SKILL.md learnings:
    - Genuine tool constraints any agent would hit (e.g., eval quirks, Playwright behavior)
    - Non-obvious failure modes with clear mitigations
    - Command interactions that aren't documented
 
-4. **Present your findings.** For each learning, show:
+   **Separate out** as feature requests or bug fixes (not SKILL.md changes):
+   - Workarounds for bugs that should be fixed in code
+   - Missing functionality the agent needed and had to hack around
+   - Misleading output or docs that don't match actual behavior
+
+4. **Present your findings.** Organize into two sections:
+
+   **SKILL.md learnings** — for each, show:
    - What happened in the transcript (brief)
    - The proposed SKILL.md addition (exact text)
    - Why it's generalizable (one sentence)
 
-   Ask the user to approve or reject each one before editing SKILL.md.
+   **Feature requests / bug fixes** — for each, show:
+   - What happened in the transcript (brief)
+   - What the CLI should do instead (proposed behavior)
+   - Whether it's a bug fix (current behavior is wrong) or a feature
+     request (new capability needed)
+
+   Ask the user to approve or reject each item before acting.
 
 5. **Consider new Scenarios.** Beyond command-level learnings, check
    whether the transcript reveals a scenario not covered in the existing
@@ -67,9 +82,14 @@ this tool — and propose targeted additions to `SKILL.md`.
    from the transcript, proposed text, and why an agent couldn't get there
    alone. Ask for approval before adding.
 
-6. **Apply approved changes** to the repo-root `SKILL.md` — add
-   command-level learnings inline to the relevant command section, and
-   scenarios to the `## Scenarios` section.
+6. **Apply approved changes.**
+   - SKILL.md learnings → add inline to the relevant command section in
+     the repo-root `SKILL.md`. Scenarios → `## Scenarios` section.
+   - Feature requests / bug fixes → we own this package, so implement
+     the fix or feature directly in the codebase. For non-trivial
+     changes, plan the implementation and confirm with the user before
+     writing code. Include the transcript evidence in commit messages
+     or PR descriptions for context.
 
 ## Anti-patterns
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# next-browser
+
+## Gotchas
+
+### Daemon caches the old build
+
+The daemon process keeps running the old `dist/` in memory. After `npm run build`, you must restart the daemon (`next-browser close` then reopen) for changes to take effect. Without this, you'll be testing stale code and wondering why your fix isn't working.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Requires Node >= 20.
 | `errors`          | Build and runtime errors for the current page                 |
 | `logs`            | Recent dev server log output                                  |
 | `network [idx]`   | List network requests, or inspect one (headers, body)         |
-| `screenshot`      | Full-page PNG to a temp file                                  |
+| `preview [caption]` | Screenshot + open in viewer window (accumulates across calls) |
+| `screenshot`      | Viewport PNG to a temp file (`--full-page` for entire page)   |
 
 ### Interaction
 
@@ -139,8 +140,8 @@ $ next-browser perf http://localhost:3000/dashboard
 $ next-browser ppr lock
 locked
 $ next-browser goto http://localhost:3000/dashboard
-$ next-browser screenshot
-/var/folders/.../next-browser-screenshot.png
+$ next-browser preview "PPR shell — locked"
+preview → /var/folders/.../next-browser-screenshot.png
 $ next-browser ppr unlock
 # PPR Shell Analysis — 131 boundaries: 3 dynamic holes, 128 static
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -58,6 +58,24 @@ command errors without an open session.
 
 ---
 
+## Keep the user in the loop visually
+
+During debug sessions, use `preview` liberally so the user can see what
+you see. Good moments to preview:
+
+- Right after opening a page or navigating, so the user confirms you're
+  on the right page.
+- After making a code change and reloading — show the before/after.
+- When inspecting the PPR shell (locked state) — the user can judge
+  shell quality faster than reading a tree dump.
+- When something looks wrong — show it, don't just describe it.
+
+Use captions to annotate what the screenshot represents (e.g.
+`preview "PPR shell — locked"`, `preview "After fix"`). This makes
+the preview window self-documenting as you iterate.
+
+---
+
 ## Commands
 
 ### `open <url> [--cookies-json <file>]`
@@ -321,14 +339,48 @@ command to change dimensions.
 
 ---
 
+### `preview [caption] [--clear]`
+
+Take a screenshot and pop it open in a separate headed Chromium window.
+**Images accumulate** — each call appends a new captioned screenshot
+below the previous ones, separated by a divider. Use `--clear` to reset
+and start fresh. The preview window is closed automatically when you run
+`close`.
+
+```
+$ next-browser preview "Before fix"
+preview → /var/folders/.../next-browser-1772770369495.png
+
+$ next-browser preview "After fix"
+preview → /var/folders/.../next-browser-1772770369496.png
+# Window now shows both images stacked vertically
+
+$ next-browser preview --clear "Fresh start"
+preview → /var/folders/.../next-browser-1772770369497.png
+# Window reset — only shows this image
+```
+
 ### `screenshot`
 
-Full-page PNG to a temp file. Returns the path. Read with the Read tool.
+Viewport PNG to a temp file. Returns the path. Read with the Read tool.
+Use `--full-page` to capture the entire scrollable page.
 
 ```
 $ next-browser screenshot
 /var/folders/.../next-browser-1772770369495.png
+
+$ next-browser screenshot --full-page
+/var/folders/.../next-browser-1772770369496.png
 ```
+
+**Always follow `screenshot` with `preview` + a caption** so the user
+can see what you see. `screenshot` alone only saves a file — the user
+has no visibility into what you captured unless you `preview` it.
+
+**For before/after comparison**, call `preview "Before"` on the original
+state, then make changes and call `preview "After"`. Both images stay
+visible in the preview window. Use `--clear` when starting a new
+comparison to reset accumulated images.
 
 Don't narrate what the screenshot shows — the user can see the browser.
 State your conclusion or next action, not a description of the page.
@@ -385,6 +437,10 @@ Three ways to target:
 **Recommended workflow:** run `snapshot` first, then `click eN`.
 Refs are the most reliable — they resolve via ARIA role+name, so they
 work even when elements have no stable CSS selector.
+
+**Clicking navigation links can timeout.** `click` on a Next.js `<Link>`
+waits for the navigation to settle, which can exceed the command timeout.
+If `click` hangs on a nav link, cancel it and use `goto <url>` instead.
 
 ```
 $ next-browser snapshot

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -11,10 +11,10 @@
  * Module-level state: one browser context, one page, one PPR lock.
  */
 
-import { readFileSync, mkdirSync } from "node:fs";
+import { readFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
-import { chromium, type BrowserContext, type Page } from "playwright";
+import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 import { instant } from "@next/playwright";
 import * as componentTree from "./tree.ts";
 import * as suspenseTree from "./suspense.ts";
@@ -38,6 +38,10 @@ let page: Page | null = null;
 let profileDirPath: string | null = null;
 let initialOrigin: string | null = null;
 let ssrLocked = false;
+
+let previewBrowser: Browser | BrowserContext | null = null;
+let previewPage: Page | null = null;
+let previewImages: { caption?: string; imgData: string; timestamp: string }[] = [];
 
 /** Install or remove the script-blocking route handler based on ssrLocked. */
 async function syncSsrRoutes() {
@@ -86,6 +90,10 @@ export async function cookies(cookies: { name: string; value: string }[], domain
 
 /** Close the browser and reset all state. */
 export async function close() {
+  await previewBrowser?.close().catch(() => {});
+  previewBrowser = null;
+  previewPage = null;
+  previewImages = [];
   await context?.close();
   context = null;
   page = null;
@@ -564,14 +572,80 @@ async function formatSource([file, line, col]: [string, number, number]) {
 
 // ── Utilities ────────────────────────────────────────────────────────────────
 
-/** Viewport screenshot saved to a temp file. Returns the file path. */
-export async function screenshot() {
+/** Take a screenshot and display it in a separate headed Chromium window.
+ *  Images accumulate across calls — use `clear` to reset. */
+export async function preview(caption?: string, clear?: boolean) {
+  if (!page) throw new Error("browser not open");
+  if (clear) previewImages = [];
+
+  const path = await screenshot();
+  const imgData = readFileSync(path).toString("base64");
+  const timestamp = new Date().toLocaleTimeString();
+  previewImages.unshift({ caption, imgData, timestamp });
+
+  const imagesHtml = previewImages
+    .map(
+      (img) =>
+        `<div style="padding:4px 12px;display:flex;align-items:baseline;gap:8px">` +
+        (img.caption
+          ? `<span style="font-size:14px">${escapeHtml(img.caption)}</span>`
+          : "") +
+        `<span style="font-size:11px;opacity:0.5">${escapeHtml(img.timestamp)}</span>` +
+        `</div>` +
+        `<img src="data:image/png;base64,${img.imgData}" style="display:block;max-width:100%">`,
+    )
+    .join(`<hr style="border:none;border-top:1px solid #333;margin:12px 0">`);
+
+  const html =
+    `<html><head><title>next-browser preview</title></head>` +
+    `<body style="margin:0;background:#111;color:#fff;font-family:system-ui">` +
+    `<div style="padding:8px 12px;font-size:11px;opacity:0.5;text-transform:uppercase;letter-spacing:0.05em">next-browser preview</div>` +
+    `${imagesHtml}` +
+    `</body></html>`;
+  const htmlPath = path.replace(/\.png$/, ".html");
+  writeFileSync(htmlPath, html);
+  const target = `file://${htmlPath}`;
+
+  // Reuse existing preview window, or launch a new one.
+  if (previewPage && !previewPage.isClosed()) {
+    try {
+      await previewPage.goto(target);
+      await previewPage.bringToFront();
+      return path;
+    } catch {
+      // Window was closed by user — fall through to launch a new one.
+      await previewBrowser?.close().catch(() => {});
+    }
+  }
+
+  const { mkdtempSync } = await import("node:fs");
+  const { join } = await import("node:path");
+  const { tmpdir } = await import("node:os");
+  const userDataDir = mkdtempSync(join(tmpdir(), "nb-preview-"));
+  const ctx = await chromium.launchPersistentContext(userDataDir, {
+    headless: false,
+    args: [`--app=${target}`, "--window-size=820,640"],
+    viewport: null,
+  });
+  previewBrowser = ctx;
+  previewPage = ctx.pages()[0] ?? (await ctx.waitForEvent("page"));
+  await previewPage.waitForLoadState();
+  await previewPage.bringToFront();
+  return path;
+}
+
+function escapeHtml(s: string) {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/** Screenshot saved to a temp file. Returns the file path. */
+export async function screenshot(opts?: { fullPage?: boolean }) {
   if (!page) throw new Error("browser not open");
   await hideDevOverlay();
   const { join } = await import("node:path");
   const { tmpdir } = await import("node:os");
   const path = join(tmpdir(), `next-browser-${Date.now()}.png`);
-  await page.screenshot({ path });
+  await page.screenshot({ path, fullPage: opts?.fullPage });
   return path;
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -154,8 +154,16 @@ if (cmd === "back") {
   exit(res, "back");
 }
 
+if (cmd === "preview") {
+  const clear = args.includes("--clear");
+  const caption = args.filter((a) => a !== "--clear").slice(1).join(" ") || undefined;
+  const res = await send("preview", { caption, clear });
+  exit(res, res.ok ? `preview → ${res.data}` : "");
+}
+
 if (cmd === "screenshot") {
-  const res = await send("screenshot");
+  const fullPage = args.includes("--full-page");
+  const res = await send("screenshot", { fullPage });
   exit(res, res.ok ? String(res.data) : "");
 }
 
@@ -362,7 +370,8 @@ function printUsage() {
       "  tree <id>          inspect component (props, hooks, state, source)\n" +
       "\n" +
       "  viewport [WxH]     show or set viewport size (e.g. 1280x720)\n" +
-      "  screenshot         save full-page screenshot to tmp file\n" +
+      "  preview [caption] [--clear]  screenshot + open in viewer (accumulates)\n" +
+      "  screenshot [--full-page]  save screenshot to tmp file\n" +
       "  snapshot           accessibility tree with interactive refs\n" +
       "  click <ref|sel>    click an element (real pointer events)\n" +
       "  fill <ref|sel> <v> fill a text input\n" +

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -57,6 +57,9 @@ type Cmd = {
   domain?: string;
   width?: number | null;
   height?: number | null;
+  fullPage?: boolean;
+  caption?: string;
+  clear?: boolean;
 };
 
 async function run(cmd: Cmd) {
@@ -88,8 +91,12 @@ async function run(cmd: Cmd) {
     const data = await browser.restart();
     return { ok: true, data };
   }
+  if (cmd.action === "preview") {
+    const data = await browser.preview(cmd.caption, cmd.clear);
+    return { ok: true, data };
+  }
   if (cmd.action === "screenshot") {
-    const data = await browser.screenshot();
+    const data = await browser.screenshot({ fullPage: cmd.fullPage });
     return { ok: true, data };
   }
   if (cmd.action === "links") {


### PR DESCRIPTION
Agents capture screenshots constantly but the user never sees them unless they manually open the temp file. `preview` fixes this — it takes a screenshot, wraps it in an HTML page, and opens it in a headed Chromium window. Images accumulate across calls (separated by captions and timestamps), so the user gets a running visual log of what the agent is doing. `--clear` resets the accumulation.

`screenshot` now captures the viewport by default instead of the full page. Pass `--full-page` to get the old full-page behavior. The viewport default is more useful for agents — it shows what's actually visible, which matches what the user would see.

The `synthesize-transcript` skill is updated to also surface feature requests and bug fixes for the CLI, not just SKILL.md learnings. When a transcript reveals a workaround for a bug or a missing feature, the skill now proposes implementing the fix directly rather than documenting the workaround.

Also adds a `CLAUDE.md` with a note about the daemon caching gotcha.