### PR TITLE
Document `NEXT_BROWSER_HEADLESS` env var in SKILL.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -58,6 +58,14 @@ command errors without an open session.
 
 ---
 
+## Headless mode
+
+By default the browser opens headed (visible window). For CI or cloud
+environments with no display, set `NEXT_BROWSER_HEADLESS=1` to run
+headless.
+
+---
+
 ## Keep the user in the loop visually
 
 During debug sessions, use `preview` liberally so the user can see what


### PR DESCRIPTION
Adds a short section to SKILL.md so agents know they can set `NEXT_BROWSER_HEADLESS=1` to run the browser without a visible window in CI or cloud environments. The browser defaults to headed mode; this just documents the existing env var.