### PR TITLE
Add `browser-logs` command for browser-side console capture

### DIFF
--- a/.changeset/browser-logs.md
+++ b/.changeset/browser-logs.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next-browser": minor
+---
+
+Add `browser-logs` command to capture browser console output

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,9 @@
 ### Daemon caches the old build
 
 The daemon process keeps running the old `dist/` in memory. After `npm run build`, you must restart the daemon (`next-browser close` then reopen) for changes to take effect. Without this, you'll be testing stale code and wondering why your fix isn't working.
+
+## Patterns
+
+### Spill long CLI output to a temp file
+
+When a CLI command may produce output that exceeds ~4 000 chars, write it to a temp file and print the path instead of dumping it inline. See `network.ts` `spillIfLong()` and the `browser-logs` handler in `cli.ts` for examples. Use `join(tmpdir(), \`next-browser-…\`)` for the path.

--- a/SKILL.md
+++ b/SKILL.md
@@ -570,6 +570,36 @@ $ next-browser logs
 {"timestamp":"00:01:55.382","source":"Browser","level":"WARN","message":"navigation-metrics: content visible was already recorded..."}
 ```
 
+### `browser-logs`
+
+Browser-side console output (`console.log`, `console.warn`, `console.error`,
+`console.info`). Captured directly from the page — works with both dev and
+production builds.
+
+```
+$ next-browser browser-logs
+[LOG  ] Initializing app
+[WARN ] Deprecation: use fetchV2 instead
+[ERROR] Failed to load resource: 404
+[INFO ] render complete in 42ms
+```
+
+Up to 500 entries are kept; oldest are dropped when the buffer is full.
+Entries accumulate across navigations within the same browser session.
+If output exceeds 4 000 chars it is written to a temp file and the path
+is printed instead.
+
+**When to use which:**
+
+| Command        | Source                           | Requires dev server |
+|----------------|----------------------------------|---------------------|
+| `logs`         | Next.js dev server stdout        | Yes                 |
+| `errors`       | Build errors + `console.error`   | Yes                 |
+| `browser-logs` | All browser console output       | No                  |
+
+For dev server diagnostics, prefer `logs` and `errors`. Use `browser-logs`
+when you need general console output or are running a production build.
+
 ---
 
 ### `network`

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -852,6 +852,14 @@ export async function mcp(tool: string, args?: Record<string, unknown>) {
   return nextMcp.call(origin, tool, args);
 }
 
+/** Return browser console output captured by the init-script interceptor. */
+export async function browserLogs() {
+  if (!page) throw new Error("browser not open");
+  return page.evaluate(
+    () => (window as any).__NEXT_BROWSER_CONSOLE_LOGS__ ?? [],
+  );
+}
+
 /** Get network request log, or detail for a specific request index. */
 export function network(idx?: number) {
   return idx == null ? net.format() : net.detail(idx);
@@ -962,6 +970,42 @@ async function launch() {
       }
       return orig.apply(console, [label, ...args] as any);
     };
+  });
+
+  // Intercept console.log/warn/error/info to capture browser console output.
+  // This works for both dev and prod builds — unlike `logs`/`errors` which
+  // rely on the Next.js dev server MCP endpoint.
+  await ctx.addInitScript(() => {
+    const MAX = 500;
+    const entries: Array<{ level: string; args: string; timestamp: number }> = [];
+    (window as any).__NEXT_BROWSER_CONSOLE_LOGS__ = entries;
+
+    function safe(val: unknown): string {
+      if (val === undefined) return "undefined";
+      if (val === null) return "null";
+      if (val instanceof Error) return `${val.name}: ${val.message}`;
+      if (typeof val === "object") {
+        try {
+          return JSON.stringify(val);
+        } catch {
+          return String(val);
+        }
+      }
+      return String(val);
+    }
+
+    for (const level of ["log", "warn", "error", "info"] as const) {
+      const orig = console[level];
+      console[level] = function (...args: any[]) {
+        entries.push({
+          level,
+          args: args.map(safe).join(" "),
+          timestamp: performance.now(),
+        });
+        if (entries.length > MAX) entries.splice(0, entries.length - MAX);
+        return orig.apply(console, args);
+      };
+    }
   });
 
   // Next.js devtools overlay is removed before each screenshot via hideDevOverlay().

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { send } from "./client.ts";
 
 const args = process.argv.slice(2);
@@ -255,6 +257,28 @@ if (cmd === "logs") {
   process.exit(0);
 }
 
+if (cmd === "browser-logs") {
+  const res = await send("browser-logs");
+  if (!res.ok) exit(res, "");
+  const entries = res.data as { level: string; args: string; timestamp: number }[];
+  if (entries.length === 0) {
+    console.log("(no console output captured)");
+    process.exit(0);
+  }
+  const lines = entries.map(
+    (e) => `[${e.level.toUpperCase().padEnd(5)}] ${e.args}`,
+  );
+  const output = lines.join("\n");
+  if (output.length > 4000) {
+    const path = join(tmpdir(), `next-browser-console-${process.pid}.log`);
+    writeFileSync(path, output);
+    console.log(`(${entries.length} entries written to ${path})`);
+  } else {
+    console.log(output);
+  }
+  process.exit(0);
+}
+
 if (cmd === "action") {
   const res = await send("mcp", { tool: "get_server_action_by_id", args: { actionId: arg } });
   exit(res, res.ok ? json(res.data) : "");
@@ -381,6 +405,7 @@ function printUsage() {
       "\n" +
       "  errors             show build/runtime errors\n" +
       "  logs               show recent dev server log output\n" +
+      "  browser-logs       show browser console output (log/warn/error/info)\n" +
       "  network [idx]      list network requests, or inspect one\n" +
       "\n" +
       "  page               show current page segments and router info\n" +

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -87,6 +87,10 @@ async function run(cmd: Cmd) {
     const data = await browser.perf(cmd.url as string | undefined);
     return { ok: true, data };
   }
+  if (cmd.action === "browser-logs") {
+    const data = await browser.browserLogs();
+    return { ok: true, data };
+  }
   if (cmd.action === "restart") {
     const data = await browser.restart();
     return { ok: true, data };


### PR DESCRIPTION
The existing `logs` and `errors` commands rely on the Next.js dev server MCP endpoint, which means they don't work for production builds and don't capture general `console.log`/`console.warn`/`console.info` output. This came up when an agent was asked to investigate a prod-only issue and had no way to read console output.

`browser-logs` installs an init script that intercepts `console.log`, `console.warn`, `console.error`, and `console.info` before any page JS runs, storing entries in a capped buffer (500 entries). Since it hooks the browser directly via Playwright's `addInitScript`, it works regardless of whether a dev server is running — making it the right tool for debugging production builds or any scenario where you need raw console output.

Output is printed inline for short logs, or spilled to a temp file when it exceeds 4 000 chars (same pattern as `network` detail).