### PR TITLE
[Renders] Distinguish mounts from re-renders in profiling output

### DIFF
--- a/.changeset/renders-mount-distinction.md
+++ b/.changeset/renders-mount-distinction.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next-browser": minor
+---
+
+Distinguish mounts from re-renders in `renders stop` output with `Insts`, `Mounts`, and `Re-renders` columns

--- a/SKILL.md
+++ b/SKILL.md
@@ -203,15 +203,15 @@ the agent decides what's actionable.
 ```
 $ next-browser renders stop
 # Render Profile — 3.05s recording
-# 426 renders across 38 components
+# 426 renders (38 mounts + 388 re-renders) across 38 components
 # FPS: avg 120, min 106, max 137, drops (<30fps): 0
 
 ## Components by total render time
-| Component              | Renders | Total    | Self     | DOM   | Top change reason          |
-| ---------------------- | ------- | -------- | -------- | ----- | -------------------------- |
-| Parent                 |      10 |   5.8ms  |   3.4ms  | 10/10 | state (hook #0)            |
-| MemoChild              |      30 |     2ms  |   1.9ms  | 30/30 | props.data                 |
-| Router                 |      10 |   6.3ms  |       —  |  0/10 | parent (ErrorBoundaryHandler) |
+| Component              | Insts | Mounts | Re-renders | Total    | Self     | DOM   | Top change reason          |
+| ---------------------- | ----- | ------ | ---------- | -------- | -------- | ----- | -------------------------- |
+| Parent                 |     1 |      1 |          9 |   5.8ms  |   3.4ms  | 10/10 | state (hook #0)            |
+| MemoChild              |     3 |      3 |         27 |     2ms  |   1.9ms  | 30/30 | props.data                 |
+| Router                 |     1 |      1 |          9 |   6.3ms  |       —  |  0/10 | parent (ErrorBoundaryHandler) |
 
 ## Change details (prev → next)
   Parent
@@ -229,7 +229,9 @@ reference — memo defeated) without needing to inspect the component.
 per component (type, name, prev, next for each render event).
 
 **Columns:**
-- `Renders` — how many times the component rendered
+- `Insts` — number of unique component instances observed during recording
+- `Mounts` — how many times an instance mounted (first render, no alternate fiber)
+- `Re-renders` — update-phase renders (total renders minus mounts)
 - `Total` — inclusive render time (component + children)
 - `Self` — exclusive render time (component only, excludes children)
 - `DOM` — how many renders actually mutated the DOM vs total renders
@@ -244,6 +246,7 @@ counts, DOM mutations, and change reasons are still reported.
 - `state (hook #N)` — a useState/useReducer hook changed, with prev→next values
 - `context (<name>)` — a specific context changed, with prev→next values
 - `parent (<name>)` — parent component re-rendered, names the parent
+- `parent (<name> (mount))` — parent is also mounting (typical during page load, not a leak)
 - `mount` — first render
 
 **FPS** — frames per second during recording. `drops` counts frames
@@ -748,13 +751,18 @@ initial load. Use `renders` to profile it. (For initial load, use `perf`.)
    navigate via `push`, or just wait if the issue is polling/timers.
 4. `renders stop` — read the raw data.
 5. Use the data to form hypotheses. The columns give you:
-   - `Renders` + `Self` — is this component expensive per-render, or
-     just called too often?
+   - `Mounts` vs `Re-renders` — is this component re-rendering after
+     load, or is the count just from mount-time cascading?
+   - `Insts` — is a high render count from many instances or one
+     instance rendering excessively?
+   - `Self` — is this component expensive per-render, or just called
+     too often?
    - `DOM` — did the renders actually produce visible changes?
      A component with 100 renders and 0 DOM mutations is doing
      purely wasted work.
    - `Total` vs `Self` — is the cost in this component or its children?
    - Change reasons — what's driving the re-renders?
+     `parent (X (mount))` is load-time cascading, not a leak.
    - FPS — are the re-renders actually causing user-visible jank?
 6. `tree` to find the component's ID, then `tree <id>` for its source
    file, props, and hooks.

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -981,7 +981,8 @@ const rendersHookScript = `(() => {
       while (parent) {
         const pName = getName(parent);
         if (pName) {
-          changes.push({ type: "parent", name: pName });
+          const suffix = !parent.alternate ? " (mount)" : "";
+          changes.push({ type: "parent", name: pName + suffix });
           break;
         }
         parent = parent.return;
@@ -1033,11 +1034,17 @@ const rendersHookScript = `(() => {
           } else {
             if (!data[name]) {
               data[name] = {
-                count: 0, totalTime: 0, selfTime: 0,
-                domMutations: 0, changes: []
+                count: 0, mounts: 0, totalTime: 0, selfTime: 0,
+                domMutations: 0, changes: [],
+                _instances: new Set()
               };
             }
             data[name].count++;
+            if (!fiber.alternate) data[name].mounts++;
+            if (!data[name]._instances.has(fiber)) {
+              data[name]._instances.add(fiber);
+              if (fiber.alternate) data[name]._instances.add(fiber.alternate);
+            }
             if (typeof fiber.actualDuration === "number") {
               data[name].totalTime += fiber.actualDuration;
               data[name].selfTime += Math.max(0, fiber.actualDuration - childrenTime(fiber));
@@ -1093,10 +1100,12 @@ export async function rendersStop() {
           string,
           {
             count: number;
+            mounts: number;
             totalTime: number;
             selfTime: number;
             domMutations: number;
             changes: Change[];
+            _instances: Set<any>;
           }
         >
       | undefined;
@@ -1142,6 +1151,8 @@ export async function rendersStop() {
         elapsed: 0,
         fps: fpsStats,
         totalRenders: 0,
+        totalMounts: 0,
+        totalReRenders: 0,
         totalComponents: 0,
         components: [],
       };
@@ -1163,6 +1174,9 @@ export async function rendersStop() {
         return {
           name,
           count: entry.count,
+          mounts: entry.mounts,
+          reRenders: entry.count - entry.mounts,
+          instanceCount: entry._instances.size,
           totalTime: round(entry.totalTime),
           selfTime: round(entry.selfTime),
           domMutations: entry.domMutations,
@@ -1172,10 +1186,13 @@ export async function rendersStop() {
       })
       .sort((a, b) => b.totalTime - a.totalTime || b.count - a.count);
 
+    const totalMounts = components.reduce((s, c) => s + c.mounts, 0);
     return {
       elapsed: round(elapsed / 1000),
       fps: fpsStats,
       totalRenders: components.reduce((s, c) => s + c.count, 0),
+      totalMounts,
+      totalReRenders: components.reduce((s, c) => s + c.reRenders, 0),
       totalComponents: components.length,
       components,
     };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -287,6 +287,9 @@ if (cmd === "renders" && arg === "stop") {
   type Component = {
     name: string;
     count: number;
+    mounts: number;
+    reRenders: number;
+    instanceCount: number;
     totalTime: number;
     selfTime: number;
     domMutations: number;
@@ -297,6 +300,8 @@ if (cmd === "renders" && arg === "stop") {
     elapsed: number;
     fps: { avg: number; min: number; max: number; drops: number };
     totalRenders: number;
+    totalMounts: number;
+    totalReRenders: number;
     totalComponents: number;
     components: Component[];
   };
@@ -321,15 +326,15 @@ if (cmd === "renders" && arg === "stop") {
 
   const lines: string[] = [
     `# Render Profile — ${d.elapsed}s recording`,
-    `# ${d.totalRenders} renders across ${d.totalComponents} components`,
+    `# ${d.totalRenders} renders (${d.totalMounts} mounts + ${d.totalReRenders} re-renders) across ${d.totalComponents} components`,
     `# FPS: avg ${d.fps.avg}, min ${d.fps.min}, max ${d.fps.max}, drops (<30fps): ${d.fps.drops}`,
     "",
     "## Components by total render time",
   ];
 
   const nameW = Math.max(9, ...d.components.slice(0, 50).map((c) => c.name.length));
-  const header = `| ${"Component".padEnd(nameW)} | Renders | Total    | Self     | DOM | Top change reason          |`;
-  const sep    = `| ${"-".repeat(nameW)} | ------- | -------- | -------- | --- | -------------------------- |`;
+  const header = `| ${"Component".padEnd(nameW)} | Insts | Mounts | Re-renders | Total    | Self     | DOM   | Top change reason          |`;
+  const sep    = `| ${"-".repeat(nameW)} | ----- | ------ | ---------- | -------- | -------- | ----- | -------------------------- |`;
   lines.push(header, sep);
 
   for (const c of d.components.slice(0, 50)) {
@@ -339,7 +344,7 @@ if (cmd === "renders" && arg === "stop") {
     const topChange = Object.entries(c.changeSummary).sort((a, b) => b[1] - a[1])[0];
     const changeStr = topChange ? topChange[0] : "—";
     lines.push(
-      `| ${c.name.padEnd(nameW)} | ${String(c.count).padStart(7)} | ${total.padStart(8)} | ${self.padStart(8)} | ${dom.padStart(3)} | ${changeStr.padEnd(26)} |`,
+      `| ${c.name.padEnd(nameW)} | ${String(c.instanceCount).padStart(5)} | ${String(c.mounts).padStart(6)} | ${String(c.reRenders).padStart(10)} | ${total.padStart(8)} | ${self.padStart(8)} | ${dom.padStart(5)} | ${changeStr.padEnd(26)} |`,
     );
   }
   if (d.components.length > 50) {


### PR DESCRIPTION
The `renders stop` table previously showed a single `Renders` column, making it hard for agents to tell whether a high render count came from mount-time cascading or actual update-phase re-renders. A component that renders 30 times during page load because its parent tree is mounting is fundamentally different from one that re-renders 30 times in response to state changes — but the old output made them look identical.

This adds three new columns: `Insts` (unique component instances observed), `Mounts` (first renders with no alternate fiber), and `Re-renders` (total minus mounts). The header line also breaks out the totals: `426 renders (38 mounts + 388 re-renders) across 38 components`.

Parent change reasons now carry a `(mount)` suffix when the parent fiber has no alternate, so `parent (App (mount))` signals load-time cascading rather than an update leak. SKILL.md is updated with the new columns, change reason variant, and guidance in the re-render scenario.