### PR TITLE
Cap screenshot dimensions to stay under LLM image limits

### DIFF
--- a/.changeset/downsize-screenshots.md
+++ b/.changeset/downsize-screenshots.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next-browser": patch
+---
+
+Cap screenshot dimensions to 1280px to stay under multi-image LLM request limits

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -635,6 +635,10 @@ function escapeHtml(s: string) {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
+/** Max screenshot dimension in pixels — keeps images under the 2000px limit
+ *  that multi-image LLM requests impose. */
+const SCREENSHOT_MAX_DIM = 1280;
+
 /** Screenshot saved to a temp file. Opens the Screenshot Log window in headed mode.
  *  Returns the file path. */
 export async function screenshot(opts?: { fullPage?: boolean; caption?: string }) {
@@ -643,7 +647,12 @@ export async function screenshot(opts?: { fullPage?: boolean; caption?: string }
   const { join } = await import("node:path");
   const { tmpdir } = await import("node:os");
   const path = join(tmpdir(), `next-browser-${Date.now()}.png`);
-  await page.screenshot({ path, fullPage: opts?.fullPage });
+  // scale: 'css' prevents Retina 2x doubling (1440x900 stays 1440x900).
+  await page.screenshot({ path, fullPage: opts?.fullPage, scale: "css" });
+
+  // Full-page screenshots can still exceed the max dimension in height.
+  // Read the PNG IHDR chunk to check and resize via canvas if needed.
+  await downsizeIfNeeded(path, SCREENSHOT_MAX_DIM);
 
   const imgData = readFileSync(path).toString("base64");
   const timestamp = new Date().toLocaleTimeString();
@@ -651,6 +660,40 @@ export async function screenshot(opts?: { fullPage?: boolean; caption?: string }
   await refreshScreenshotLog();
 
   return path;
+}
+
+/** Downsize a PNG on disk if either dimension exceeds `maxDim`. Uses the
+ *  browser page's canvas to resize — no extra dependencies needed. */
+async function downsizeIfNeeded(filePath: string, maxDim: number) {
+  const buf = readFileSync(filePath);
+  // PNG IHDR: width at byte 16, height at byte 20 (big-endian uint32).
+  if (buf.length < 24) return;
+  const w = buf.readUInt32BE(16);
+  const h = buf.readUInt32BE(20);
+  if (w <= maxDim && h <= maxDim) return;
+  if (!page) return;
+
+  const b64 = buf.toString("base64");
+  const resized: string = await page.evaluate(
+    async ({ src, max }: { src: string; max: number }) => {
+      const img = new Image();
+      await new Promise<void>((resolve, reject) => {
+        img.onload = () => resolve();
+        img.onerror = () => reject(new Error("img load failed"));
+        img.src = `data:image/png;base64,${src}`;
+      });
+      const scale = Math.min(max / img.width, max / img.height, 1);
+      const nw = Math.round(img.width * scale);
+      const nh = Math.round(img.height * scale);
+      const canvas = document.createElement("canvas");
+      canvas.width = nw;
+      canvas.height = nh;
+      canvas.getContext("2d")!.drawImage(img, 0, 0, nw, nh);
+      return canvas.toDataURL("image/png").split(",")[1]!;
+    },
+    { src: b64, max: maxDim },
+  );
+  writeFileSync(filePath, Buffer.from(resized, "base64"));
 }
 
 /** Remove Next.js devtools overlay from the page before screenshots. */

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -11,7 +11,7 @@
  * Module-level state: one browser context, one page, one PPR lock.
  */
 
-import { readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { readFileSync, mkdirSync, writeFileSync, unlinkSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
@@ -640,60 +640,108 @@ function escapeHtml(s: string) {
 const SCREENSHOT_MAX_DIM = 1280;
 
 /** Screenshot saved to a temp file. Opens the Screenshot Log window in headed mode.
- *  Returns the file path. */
+ *  Returns the file path for a single image, or a directory path when the
+ *  image is sliced into multiple chunks (full-page on long pages). */
 export async function screenshot(opts?: { fullPage?: boolean; caption?: string }) {
   if (!page) throw new Error("browser not open");
   await hideDevOverlay();
-  const { join } = await import("node:path");
-  const { tmpdir } = await import("node:os");
   const path = join(tmpdir(), `next-browser-${Date.now()}.png`);
   // scale: 'css' prevents Retina 2x doubling (1440x900 stays 1440x900).
   await page.screenshot({ path, fullPage: opts?.fullPage, scale: "css" });
 
-  // Full-page screenshots can still exceed the max dimension in height.
-  // Read the PNG IHDR chunk to check and resize via canvas if needed.
-  await downsizeIfNeeded(path, SCREENSHOT_MAX_DIM);
-
-  const imgData = readFileSync(path).toString("base64");
+  const result = await sliceIfNeeded(path, SCREENSHOT_MAX_DIM);
   const timestamp = new Date().toLocaleTimeString();
-  screenshotEntries.unshift({ caption: opts?.caption, imgData, timestamp });
+
+  if (typeof result === "string") {
+    // Single file — fits within limits.
+    const imgData = readFileSync(result).toString("base64");
+    screenshotEntries.unshift({ caption: opts?.caption, imgData, timestamp });
+  } else {
+    // Multiple chunks — add each to the screenshot log.
+    for (const chunk of result.files) {
+      const imgData = readFileSync(chunk).toString("base64");
+      const label = opts?.caption
+        ? `${opts.caption} (${result.files.indexOf(chunk) + 1}/${result.files.length})`
+        : `chunk ${result.files.indexOf(chunk) + 1}/${result.files.length}`;
+      screenshotEntries.unshift({ caption: label, imgData, timestamp });
+    }
+  }
   await refreshScreenshotLog();
 
-  return path;
+  return typeof result === "string" ? result : result.dir;
 }
 
-/** Downsize a PNG on disk if either dimension exceeds `maxDim`. Uses the
- *  browser page's canvas to resize — no extra dependencies needed. */
-async function downsizeIfNeeded(filePath: string, maxDim: number) {
+/** If the screenshot fits within `maxDim`, scale it in-place and return the
+ *  path. Otherwise slice it into ≤maxDim chunks inside a temp directory and
+ *  return `{ dir, files }`. */
+async function sliceIfNeeded(
+  filePath: string,
+  maxDim: number,
+): Promise<string | { dir: string; files: string[] }> {
   const buf = readFileSync(filePath);
-  // PNG IHDR: width at byte 16, height at byte 20 (big-endian uint32).
-  if (buf.length < 24) return;
+  if (buf.length < 24) return filePath;
   const w = buf.readUInt32BE(16);
   const h = buf.readUInt32BE(20);
-  if (w <= maxDim && h <= maxDim) return;
-  if (!page) return;
+  if (w <= maxDim && h <= maxDim) return filePath;
+  if (!page) return filePath;
 
   const b64 = buf.toString("base64");
-  const resized: string = await page.evaluate(
-    async ({ src, max }: { src: string; max: number }) => {
+  const wScale = Math.min(maxDim / w, 1);
+  const scaledW = Math.round(w * wScale);
+  const scaledH = Math.round(h * wScale);
+
+  if (scaledH <= maxDim) {
+    // Fits after width scaling — single resized file.
+    const resized: string = await page.evaluate(
+      async ({ src, nw, nh }: { src: string; nw: number; nh: number }) => {
+        const img = new Image();
+        await new Promise<void>((r, e) => { img.onload = () => r(); img.onerror = () => e(); img.src = `data:image/png;base64,${src}`; });
+        const c = document.createElement("canvas");
+        c.width = nw; c.height = nh;
+        c.getContext("2d")!.drawImage(img, 0, 0, nw, nh);
+        return c.toDataURL("image/png").split(",")[1]!;
+      },
+      { src: b64, nw: scaledW, nh: scaledH },
+    );
+    writeFileSync(filePath, Buffer.from(resized, "base64"));
+    return filePath;
+  }
+
+  // Slice into chunks of maxDim height (in scaled pixels).
+  const chunkCount = Math.ceil(scaledH / maxDim);
+  const chunks: string[] = await page.evaluate(
+    async ({ src, nw, totalH, max, count }: {
+      src: string; nw: number; totalH: number; max: number; count: number;
+    }) => {
       const img = new Image();
-      await new Promise<void>((resolve, reject) => {
-        img.onload = () => resolve();
-        img.onerror = () => reject(new Error("img load failed"));
-        img.src = `data:image/png;base64,${src}`;
-      });
-      const scale = Math.min(max / img.width, max / img.height, 1);
-      const nw = Math.round(img.width * scale);
-      const nh = Math.round(img.height * scale);
-      const canvas = document.createElement("canvas");
-      canvas.width = nw;
-      canvas.height = nh;
-      canvas.getContext("2d")!.drawImage(img, 0, 0, nw, nh);
-      return canvas.toDataURL("image/png").split(",")[1]!;
+      await new Promise<void>((r, e) => { img.onload = () => r(); img.onerror = () => e(); img.src = `data:image/png;base64,${src}`; });
+      const results: string[] = [];
+      for (let i = 0; i < count; i++) {
+        const sy = (i * max) / (totalH / img.height);
+        const sh = Math.min(max, totalH - i * max) / (totalH / img.height);
+        const dh = Math.min(max, totalH - i * max);
+        const c = document.createElement("canvas");
+        c.width = nw; c.height = dh;
+        c.getContext("2d")!.drawImage(img, 0, sy, img.width, sh, 0, 0, nw, dh);
+        results.push(c.toDataURL("image/png").split(",")[1]!);
+      }
+      return results;
     },
-    { src: b64, max: maxDim },
+    { src: b64, nw: scaledW, totalH: scaledH, max: maxDim, count: chunkCount },
   );
-  writeFileSync(filePath, Buffer.from(resized, "base64"));
+
+  const dir = join(tmpdir(), `next-browser-screenshots-${Date.now()}`);
+  mkdirSync(dir, { recursive: true });
+  const files: string[] = [];
+  for (let i = 0; i < chunks.length; i++) {
+    const p = join(dir, `${String(i + 1).padStart(3, "0")}.png`);
+    writeFileSync(p, Buffer.from(chunks[i], "base64"));
+    files.push(p);
+  }
+  // Clean up the original full file.
+  unlinkSync(filePath);
+
+  return { dir, files };
 }
 
 /** Remove Next.js devtools overlay from the page before screenshots. */


### PR DESCRIPTION
Screenshots from Retina displays produce 2x images (a 1440×900 viewport becomes 2880×1800), which exceeds the 2000px dimension limit that multi-image LLM requests impose. Full-page screenshots on any display can also exceed it in height.

Two fixes in `screenshot()`: `scale: 'css'` on the Playwright call prevents device-pixel-ratio doubling, and a `downsizeIfNeeded` pass reads the PNG IHDR chunk and proportionally resizes via the browser page's canvas if either dimension still exceeds 1280px. No new dependencies.