### PR TITLE
[Skill] Teach agents to diagnose PPR error overlay in locked screenshots

### DIFF
--- a/.changeset/ppr-error-overlay-skill.md
+++ b/.changeset/ppr-error-overlay-skill.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next-browser": patch
+---
+
+Teach agents to diagnose PPR error overlay in locked screenshots

--- a/skills/next-browser/SKILL.md
+++ b/skills/next-browser/SKILL.md
@@ -377,7 +377,12 @@ blockers) not already in the table.
 
 **`errors` doesn't report while locked.** If the shell looks wrong (empty,
 bailed to CSR), unlock and `goto` the page normally, then run `errors`.
-Don't debug blind under the lock.
+Don't debug blind under the lock. A common symptom: the PPR shell
+screenshot shows the Next.js error overlay (a white box with "Runtime
+Error" and a call stack). This means the page errored during prerender,
+but you can't read the error details from the screenshot alone. Unlock,
+navigate to the page normally (`goto`), then run `errors` to get the
+full error message and stack trace.
 
 **Full bailout (scrollHeight = 0).** When PPR bails out completely, `unlock`
 returns just "unlocked" with no shell analysis — there are no boundaries to


### PR DESCRIPTION
When the PPR shell screenshot shows the Next.js error overlay, agents can't read the error details from the image alone. This adds guidance to the `errors` tip in SKILL.md: recognize the white "Runtime Error" box as a prerender failure, then unlock and navigate normally to get the actual error message via `errors`.