### PR TITLE
Add instrumentation set/clear commands for injecting scripts before page scripts

### DIFF
--- a/.changeset/instrumentation-commands.md
+++ b/.changeset/instrumentation-commands.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next-browser": minor
+---
+
+Add `instrumentation set/clear` commands for injecting scripts before page scripts

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Requires Node >= 20.
 
 | Command                              | Description                                        |
 | ------------------------------------ | -------------------------------------------------- |
-| `open <url> [--cookies-json <file>]` | Launch browser and navigate (with optional cookies) |
+| `open <url> [--cookies <file>]`      | Launch browser and navigate (with optional cookies) |
 | `close`                              | Close browser and kill daemon                      |
 
 ### Navigation
@@ -62,9 +62,9 @@ Requires Node >= 20.
 | `snapshot`        | Accessibility tree with `[ref=eN]` markers on interactive elements |
 | `errors`          | Build and runtime errors for the current page                 |
 | `logs`            | Recent dev server log output                                  |
+| `browser-logs`    | Browser console output (log, warn, error, info)               |
 | `network [idx]`   | List network requests, or inspect one (headers, body)         |
-| `preview [caption]` | Screenshot + open in viewer window (accumulates across calls) |
-| `screenshot`      | Viewport PNG to a temp file (`--full-page` for entire page)   |
+| `screenshot [caption] [--full-page]` | Viewport PNG to a temp file (caption shown in Screenshot Log) |
 
 ### Interaction
 
@@ -77,11 +77,20 @@ Requires Node >= 20.
 
 ### Performance & PPR
 
-| Command        | Description                                                  |
-| -------------- | ------------------------------------------------------------ |
-| `perf [url]`   | Core Web Vitals + React hydration timing in one pass         |
-| `ppr lock`     | Freeze dynamic content to inspect the static shell           |
-| `ppr unlock`   | Resume dynamic content and print shell analysis              |
+| Command                        | Description                                          |
+| ------------------------------ | ---------------------------------------------------- |
+| `perf [url]`                   | Core Web Vitals + React hydration timing in one pass |
+| `renders start`                | Start recording React re-renders                     |
+| `renders stop [--json]`        | Stop and print per-component render profile          |
+| `ppr lock`                     | Freeze dynamic content to inspect the static shell   |
+| `ppr unlock`                   | Resume dynamic content and print shell analysis      |
+
+### Instrumentation
+
+| Command                        | Description                                          |
+| ------------------------------ | ---------------------------------------------------- |
+| `instrumentation set <path>`   | Inject script before page scripts on every navigation |
+| `instrumentation clear`        | Remove instrumentation script                        |
 
 ### Next.js MCP
 

--- a/skills/next-browser/SKILL.md
+++ b/skills/next-browser/SKILL.md
@@ -783,6 +783,40 @@ Inspect a server action by its ID (from `next-action` header in network list).
 
 ---
 
+### `instrumentation set <path>`
+
+Inject a JavaScript file that runs before page scripts on every navigation.
+The script is registered via Playwright's `addInitScript` and also evaluated
+immediately on the current page.
+
+Use this to intercept or patch globals before the app boots — for example,
+shimming `fetch`, collecting timing data, or stubbing APIs.
+
+```
+$ cat /tmp/patch-fetch.js
+const _fetch = window.fetch;
+window.fetch = (...args) => { console.log('fetch', args[0]); return _fetch(...args); };
+
+$ next-browser instrumentation set /tmp/patch-fetch.js
+instrumentation set
+```
+
+Each `set` replaces the previous instrumentation. Only one script is active
+at a time.
+
+### `instrumentation clear`
+
+Remove the active instrumentation script. Future navigations run without it.
+Does not undo effects already applied to the current page — reload to get a
+clean state.
+
+```
+$ next-browser instrumentation clear
+instrumentation cleared
+```
+
+---
+
 ## Scenarios
 
 ### Debugging rendering performance

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -38,6 +38,7 @@ let page: Page | null = null;
 let profileDirPath: string | null = null;
 let initialOrigin: string | null = null;
 let ssrLocked = false;
+let instrumentationVersion = 0;
 
 let screenshotBrowser: Browser | BrowserContext | null = null;
 let screenshotPage: Page | null = null;
@@ -106,6 +107,7 @@ export async function close() {
   release = null;
   settled = null;
   ssrLocked = false;
+  instrumentationVersion = 0;
   // Clean up temp profile directory.
   if (profileDirPath) {
     const { rmSync } = await import("node:fs");
@@ -113,6 +115,33 @@ export async function close() {
     profileDirPath = null;
     initialOrigin = null;
   }
+}
+
+// ── Instrumentation ─────────────────────────────────────────────────────────
+//
+// addInitScript can't be removed, so we version-gate: each `set` bumps the
+// version and registers a new script that only runs when its version matches.
+// `clear` bumps the version with no matching script, disabling the old one.
+
+export async function instrumentationSet(script: string) {
+  if (!page) throw new Error("browser not open");
+  const ctx = page.context();
+  const v = ++instrumentationVersion;
+
+  // The version gate runs first, then the guarded script.
+  await ctx.addInitScript(`window.__NB_IV__=${v}`);
+  await ctx.addInitScript(`if(window.__NB_IV__===${v}){${script}}`);
+
+  // Apply immediately on the current page.
+  await page.evaluate(script);
+}
+
+export async function instrumentationClear() {
+  if (!page) throw new Error("browser not open");
+  const ctx = page.context();
+  // Bump version — no matching script, so nothing runs.
+  const v = ++instrumentationVersion;
+  await ctx.addInitScript(`window.__NB_IV__=${v}`);
 }
 
 // ── PPR lock/unlock ──────────────────────────────────────────────────────────

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -423,6 +423,22 @@ if (cmd === "viewport") {
   exit(res, `${data.width}x${data.height}`);
 }
 
+if (cmd === "instrumentation" && arg === "set") {
+  const filePath = args[2];
+  if (!filePath) {
+    console.error("usage: next-browser instrumentation set <path>");
+    process.exit(1);
+  }
+  const script = readFileSync(filePath, "utf-8");
+  const res = await send("instrumentation-set", { instrumentationScript: script });
+  exit(res, "instrumentation set");
+}
+
+if (cmd === "instrumentation" && arg === "clear") {
+  const res = await send("instrumentation-clear");
+  exit(res, "instrumentation cleared");
+}
+
 if (cmd === "close") {
   const res = await send("close");
   exit(res, "closed");
@@ -528,6 +544,9 @@ function printUsage() {
       "  page               show current page segments and router info\n" +
       "  project            show project path and dev server url\n" +
       "  routes             list app routes\n" +
-      "  action <id>        inspect a server action by id",
+      "  action <id>        inspect a server action by id\n" +
+      "\n" +
+      "  instrumentation set <path>  inject script before page scripts\n" +
+      "  instrumentation clear       remove instrumentation script",
   );
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -50,6 +50,7 @@ type Cmd = {
   tool?: string;
   args?: Record<string, unknown>;
   script?: string;
+  instrumentationScript?: string;
   selector?: string;
   value?: string;
   idx?: number;
@@ -169,6 +170,14 @@ async function run(cmd: Cmd) {
     }
     const data = await browser.viewportSize();
     return { ok: true, data };
+  }
+  if (cmd.action === "instrumentation-set") {
+    await browser.instrumentationSet(cmd.instrumentationScript!);
+    return { ok: true };
+  }
+  if (cmd.action === "instrumentation-clear") {
+    await browser.instrumentationClear();
+    return { ok: true };
   }
   if (cmd.action === "close") {
     await browser.close();


### PR DESCRIPTION
Agents sometimes need to intercept or instrument page behavior before application scripts run — for example, patching `fetch`, shimming globals, or collecting timing data. This adds `instrumentation set <path>` and `instrumentation clear` commands that inject a script via Playwright's `addInitScript` and also evaluate it immediately on the current page.

Since `addInitScript` registrations can't be removed, the implementation version-gates them: each `set` bumps a counter (`instrumentationVersion`) and wraps the script in `if(window.__NB_IV__===N){…}`. `clear` bumps the counter without a matching script, so old injections stop running on subsequent navigations. SKILL.md and README need entries for the new commands.