### PR TITLE
Capture `suspendedBy` data mid-transition before boundaries resolve

### DIFF
--- a/.changeset/hungry-geckos-burn.md
+++ b/.changeset/hungry-geckos-burn.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next-browser": patch
+---
+
+Capture `suspendedBy` data mid-transition before boundaries resolve

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -218,11 +218,59 @@ export async function unlock() {
   await page.waitForLoadState("load").catch(() => {});
   await waitForDevToolsReconnect(page);
 
+  // Capture an intermediate snapshot while boundaries are still suspended
+  // but now visible (dynamic content is streaming in). This captures the
+  // suspendedBy data that's only available while boundaries are actively
+  // suspended — once they resolve, suspendedBy is cleared.
+  // Poll briefly to catch boundaries mid-suspension.
+  let midTransition: suspenseTree.Boundary[] = [];
+  for (let attempt = 0; attempt < 6; attempt++) {
+    await new Promise((r) => setTimeout(r, 200));
+    const snap = await suspenseTree.snapshot(page).catch(() => [] as suspenseTree.Boundary[]);
+    const hasSuspendedWithData = snap.some(
+      (b) => b.isSuspended && (b.suspendedBy.length > 0 || b.unknownSuspenders),
+    );
+    if (hasSuspendedWithData || snap.some((b) => b.suspendedBy.length > 0)) {
+      midTransition = snap;
+      break;
+    }
+    // Even if no suspendedBy yet, keep the latest snapshot with any suspended boundaries
+    if (snap.some((b) => b.isSuspended)) {
+      midTransition = snap;
+    }
+  }
+
   // Wait for all boundaries to resolve after unlock.
   await waitForSuspenseToSettle(page);
 
-  // Capture the fully-resolved state with rich suspendedBy data.
+  // Capture the fully-resolved state.
   const unlocked = await suspenseTree.snapshot(page).catch(() => [] as suspenseTree.Boundary[]);
+
+  // Merge suspendedBy from mid-transition into unlocked boundaries.
+  // This preserves blocker info that's lost once boundaries resolve.
+  if (midTransition.length > 0) {
+    const midByKey = new Map<string, suspenseTree.Boundary>();
+    for (const b of midTransition) midByKey.set(suspenseTree.boundaryKey(b), b);
+    for (const b of unlocked) {
+      if (b.suspendedBy.length === 0) {
+        const mid = midByKey.get(suspenseTree.boundaryKey(b));
+        if (mid && mid.suspendedBy.length > 0) {
+          b.suspendedBy = mid.suspendedBy;
+          b.unknownSuspenders = mid.unknownSuspenders ?? b.unknownSuspenders;
+        }
+      }
+    }
+    // Also merge into locked boundaries
+    for (const b of locked) {
+      if (b.suspendedBy.length === 0) {
+        const mid = midByKey.get(suspenseTree.boundaryKey(b));
+        if (mid && mid.suspendedBy.length > 0) {
+          b.suspendedBy = mid.suspendedBy;
+          b.unknownSuspenders = mid.unknownSuspenders ?? b.unknownSuspenders;
+        }
+      }
+    }
+  }
 
   if (locked.length === 0 && unlocked.length === 0) {
     return { text: "No suspense boundaries detected.", boundaries: unlocked, locked, report: null };

--- a/src/suspense.ts
+++ b/src/suspense.ts
@@ -139,10 +139,13 @@ export async function formatAnalysis(
   return formatReport(report);
 }
 
+export type ShellContext = "push" | "goto";
+
 export async function analyzeBoundaries(
   unlocked: Boundary[],
   locked: Boundary[],
   origin: string,
+  context: ShellContext = "push",
 ): Promise<AnalysisReport> {
   await resolveSources(unlocked, origin);
   await resolveSources(locked, origin);
@@ -178,7 +181,7 @@ export async function analyzeBoundaries(
   }
 
   const holeInsights = holes
-    .map(({ shell, full }) => buildBoundaryInsight(shell, full ?? shell))
+    .map(({ shell, full }) => buildBoundaryInsight(shell, full ?? shell, context))
     .sort(compareBoundaryInsights);
   const staticSummaries = statics.map((b) => ({
     id: b.id,
@@ -326,16 +329,35 @@ export function formatReport(report: AnalysisReport): string {
 function buildBoundaryInsight(
   shell: Boundary,
   resolved: Boundary,
+  context: ShellContext = "push",
 ): BoundaryInsight {
   const boundaryKind = inferBoundaryKind(resolved);
-  const blockers = resolved.suspendedBy
-    .map((blocker) => buildActionableBlocker(blocker))
+  // Prefer suspendedBy from the locked (shell) snapshot — that's when
+  // boundaries are actively suspended and have blocker info. By the time
+  // we take the unlocked snapshot, boundaries have resolved and
+  // suspendedBy is empty.
+  const suspenderSource =
+    shell.suspendedBy.length > 0 ? shell.suspendedBy : resolved.suspendedBy;
+  const blockers = suspenderSource
+    .map((blocker) => {
+      const ab = buildActionableBlocker(blocker);
+      // In push (client navigation) context, client hooks like usePathname/
+      // useSearchParams resolve instantly on the client — they only suspend
+      // during SSR prerender. Deprioritize them so server IO blockers
+      // (cookies, headers, connection) surface as the primary blocker.
+      if (context === "push" && ab.kind === "client-hook") {
+        ab.actionability = Math.max(ab.actionability - 60, 5);
+      }
+      return ab;
+    })
     .sort(compareActionableBlockers);
   const primaryBlocker = blockers[0] ?? null;
+  const unknownSuspenders =
+    shell.unknownSuspenders ?? resolved.unknownSuspenders;
   const recommendation = recommendBoundaryFix(
     boundaryKind,
     primaryBlocker,
-    resolved.unknownSuspenders,
+    unknownSuspenders,
   );
 
   return {
@@ -352,7 +374,7 @@ function buildBoundaryInsight(
     },
     primaryBlocker,
     blockers,
-    unknownSuspenders: resolved.unknownSuspenders,
+    unknownSuspenders,
     actionability: Math.max(primaryBlocker?.actionability ?? 0, boundaryKind === "route-segment" ? 55 : 0),
     recommendation: recommendation.text,
     recommendationKind: recommendation.kind,
@@ -681,7 +703,7 @@ function normalizeBoundarySegmentName(name: string | null): string | null {
   return name.endsWith("/") ? name.slice(0, -1) : name;
 }
 
-function boundaryKey(b: Boundary): string {
+export function boundaryKey(b: Boundary): string {
   if (b.jsxSource) return `${b.jsxSource[0]}:${b.jsxSource[1]}:${b.jsxSource[2]}`;
   return b.name ?? `id-${b.id}`;
 }


### PR DESCRIPTION
`suspendedBy` on a Suspense boundary is only populated while the boundary is actively suspended. Once it resolves, the data is cleared — so the final unlocked snapshot has empty `suspendedBy` arrays, and the agent never sees what was actually blocking each hole.

The fix adds a mid-transition polling step in `unlock()` that captures a snapshot while boundaries are still suspended but dynamic content is streaming in. This snapshot's `suspendedBy` data is then merged back into both the locked and unlocked boundary arrays, keyed by `boundaryKey`. The analysis layer (`buildBoundaryInsight`) now also prefers the shell snapshot's `suspendedBy` over the resolved snapshot's, and accepts a `ShellContext` (`"push"` | `"goto"`) so client-only hooks like `usePathname` can be deprioritized during client navigations where they resolve instantly.