### PR TITLE
Add --insecure flag to open for self-signed/mismatched certs

### DIFF
--- a/.changeset/insecure-open-flag.md
+++ b/.changeset/insecure-open-flag.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next-browser": minor
+---
+
+Add `--insecure` flag to `open` command. When set, launches the browser with TLS certificate validation disabled (`ignoreHTTPSErrors` + `--ignore-certificate-errors`), so dev servers with self-signed or CN-mismatched certs — e.g. Next.js `--experimental-https` on a custom hostname — can be loaded without a cert interstitial.

--- a/skills/next-browser/SKILL.md
+++ b/skills/next-browser/SKILL.md
@@ -105,10 +105,14 @@ Two things that implies:
 
 ## Commands
 
-### `open <url> [--cookies <file>]`
+### `open <url> [--cookies <file>] [--insecure]`
 
 Launch browser, navigate to URL. With `--cookies`, sets auth cookies
-before navigating (domain derived from URL hostname).
+before navigating (domain derived from URL hostname). With `--insecure`,
+disables TLS certificate validation for the whole browser session — use
+only for local dev servers with self-signed or mismatched certs (e.g.
+Next.js `--experimental-https` on a hostname other than `localhost`).
+Do not use against URLs you do not control.
 
 ```
 $ next-browser open http://localhost:3024/vercel --cookies cookies.curl

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -69,11 +69,14 @@ async function syncSsrRoutes() {
  * The first call spawns Chromium with the DevTools extension; subsequent calls
  * reuse the existing context.
  */
-export async function open(url: string | undefined) {
+export async function open(
+  url: string | undefined,
+  opts: { insecure?: boolean } = {},
+) {
   if (context) {
     await close();
   }
-  context = await launch();
+  context = await launch({ insecure: opts.insecure });
   page = context.pages()[0] ?? (await context.newPage());
   net.attach(page);
   if (url) {
@@ -1434,7 +1437,7 @@ export async function viewportSize() {
  *
  * Set NEXT_BROWSER_HEADLESS=1 for cloud/CI environments (no display).
  */
-async function launch() {
+async function launch(opts: { insecure?: boolean } = {}) {
   const headless = !!process.env.NEXT_BROWSER_HEADLESS;
   const dir = join(tmpdir(), `next-browser-profile-${process.pid}`);
   mkdirSync(dir, { recursive: true });
@@ -1443,10 +1446,12 @@ async function launch() {
   const ctx = await chromium.launchPersistentContext(dir, {
     headless,
     viewport: null,
+    ...(opts.insecure ? { ignoreHTTPSErrors: true } : {}),
     // --no-sandbox is required when Chrome runs as root (common in containers/cloud sandboxes)
     args: [
       ...(headless ? ["--no-sandbox"] : []),
       "--window-size=1440,900",
+      ...(opts.insecure ? ["--ignore-certificate-errors"] : []),
     ],
   });
   await ctx.addInitScript(installHook);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,9 @@ if (cmd === "--version" || cmd === "-v") {
 
 if (cmd === "open") {
   if (!arg) {
-    console.error("usage: next-browser open <url> [--cookies <file>]");
+    console.error(
+      "usage: next-browser open <url> [--cookies <file>] [--insecure]",
+    );
     process.exit(1);
   }
   const url = /^https?:\/\//.test(arg) ? arg : `http://${arg}`;
@@ -32,9 +34,10 @@ if (cmd === "open") {
     return args.indexOf("--cookies-json"); // back-compat alias
   })();
   const cookieFile = cookieIdx >= 0 ? args[cookieIdx + 1] : undefined;
+  const insecure = args.includes("--insecure");
 
   if (cookieFile) {
-    const res = await send("open");
+    const res = await send("open", { insecure });
     if (!res.ok) exit(res, "");
     let cookies;
     try {
@@ -50,7 +53,7 @@ if (cmd === "open") {
     exit(res, `opened → ${url} (${cookies.length} cookies for ${domain})`);
   }
 
-  const res = await send("open", { url });
+  const res = await send("open", { url, insecure });
   exit(res, `opened → ${url}`);
 }
 
@@ -514,7 +517,7 @@ function printUsage() {
   console.error(
     "usage: next-browser <command> [args]\n" +
       "\n" +
-      "  open <url> [--cookies <file>]  launch browser and navigate\n" +
+      "  open <url> [--cookies <file>] [--insecure]  launch browser and navigate\n" +
       "  close              close browser and daemon\n" +
       "\n" +
       "  goto <url>         full-page navigation (new document load)\n" +

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -60,11 +60,12 @@ type Cmd = {
   height?: number | null;
   fullPage?: boolean;
   caption?: string;
+  insecure?: boolean;
 };
 
 async function run(cmd: Cmd) {
   if (cmd.action === "open") {
-    await browser.open(cmd.url);
+    await browser.open(cmd.url, { insecure: cmd.insecure });
     return { ok: true };
   }
   if (cmd.action === "cookies") {


### PR DESCRIPTION
## Summary

  Adds an optional `--insecure` flag to `next-browser open` that disables TLS certificate validation for the launched browser session. Default behavior is unchanged — the flag is strictly opt-in.

  ## Motivation

  Next.js `--experimental-https` generates a self-signed cert whose CN is `localhost`. Dev servers commonly run on a custom hostname (e.g. `https://local.myapp.com:8080`) either because the app
  hard-codes it or because auth/cookies require a non-`localhost` origin. In that setup Chromium rejects the cert with `NET::ERR_CERT_COMMON_NAME_INVALID`, and `next-browser open` exits with:

  error: net::ERR_CERT_COMMON_NAME_INVALID at https://local.myapp.com:8080/

  There's currently no CLI path to bypass this — users have to fall back to patching the global install. `--insecure` matches the curl convention for the same use case.

  ## Changes

  - `src/cli.ts` — parses `--insecure` on `open`; forwards to the daemon alongside `url`. Usage line and `--help` updated.
  - `src/daemon.ts` — `Cmd.insecure?: boolean`; passed through on the `open` action.
  - `src/browser.ts` — `open()` and `launch()` accept `{ insecure }`. When true, `launchPersistentContext` gets `ignoreHTTPSErrors: true` and `--ignore-certificate-errors` is added to Chromium args.
  When false (default), nothing changes.
  - `skills/next-browser/SKILL.md` — documents the flag under `open` with a warning to only use against local dev / self-signed certs you control.
  - `.changeset/insecure-open-flag.md` — minor bump.

  Scope is limited to the primary browser context. The Screenshot Log window's `launchPersistentContext` is untouched — it only displays captured PNGs locally and doesn't talk to the dev server.

  ## Test plan

  - [x] `pnpm typecheck` — clean
  - [x] `pnpm build` — clean
  - [x] `next-browser open https://local.<app>.com:8080 --insecure` — opens, page renders, screenshot capture works end-to-end
  - [x] `next-browser open https://local.<app>.com:8080` (no flag) — still fails with `ERR_CERT_COMMON_NAME_INVALID` (gating confirmed; default unchanged)
  - [x] `open <url> --cookies <file> --insecure` path accepted — flag is forwarded through both the cookie-present and cookie-absent branches

  ## Notes for reviewers

  - `--insecure` affects the whole browser session, not just the first navigation — any `goto`/`push`/`reload` under the same `open` is also unvalidated. This matches the mental model of "I launched an
   insecure browser for local dev" and avoids per-command flag proliferation.
  - No env var equivalent (e.g. `NEXT_BROWSER_INSECURE`) was added — keeping the opt-in explicit at the call site.