### PR TITLE
Add open --local-storage to seed localStorage tokens for SPA auth

### DIFF
--- a/.changeset/wild-otters-cheer.md
+++ b/.changeset/wild-otters-cheer.md
@@ -1,0 +1,5 @@
+---
+"@vercel/next-browser": minor
+---
+
+Add `open --local-storage <file>` to seed `localStorage` before the first navigation, for SPAs that authenticate their data layer with a token in `localStorage` rather than a cookie. Accepts `{"key":"value", …}` (what `JSON.stringify(localStorage)` produces) or `[{"name","value"}, …]`, is origin-guarded, re-seeds on every navigation, and combines with `--cookies`. Adds a SKILL.md scenario for diagnosing cookie-vs-token SPA auth.

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Requires Node >= 20.
 
 ### Browser lifecycle
 
-| Command                              | Description                                        |
-| ------------------------------------ | -------------------------------------------------- |
-| `open <url> [--cookies <file>]`      | Launch browser and navigate (with optional cookies) |
-| `close`                              | Close browser and kill daemon                      |
+| Command                                                  | Description                                               |
+| -------------------------------------------------------- | --------------------------------------------------------- |
+| `open <url> [--cookies <file>] [--local-storage <file>]` | Launch browser and navigate (auth: cookies, localStorage) |
+| `close`                                                  | Close browser and kill daemon                             |
 
 ### Navigation
 

--- a/prototypes/auth-localstorage/README.md
+++ b/prototypes/auth-localstorage/README.md
@@ -1,0 +1,43 @@
+# auth-localstorage prototype
+
+Minimal fixture for validating `next-browser open --local-storage <file>`
+end-to-end. Reproduces issue #13: a SPA whose data-fetching layer
+authenticates with a token in `localStorage`, not a cookie.
+
+## Run
+
+```
+node server.mjs
+```
+
+Default port is 3457.
+
+## Routes
+
+- `GET /` — SPA shell. Inline JS reads `localStorage.auth_token` and calls
+  `/api/scene` with an `Authorization: Bearer <token>` header.
+- `GET /api/scene` — requires `Authorization: Bearer dev-token-xyz`.
+  Returns the scene JSON with it, 401 without.
+
+## Test localStorage file
+
+`localstorage.json` is the object form — exactly what
+`copy(JSON.stringify(localStorage))` produces in DevTools — containing the
+expected `auth_token`. The CLI seeds it via `addInitScript` before the first
+navigation, so the token is present when the SPA's `fetch` runs.
+
+## Validation run
+
+```
+# terminal 1
+node server.mjs
+
+# terminal 2 — WITHOUT the token: shows "We couldn't open this scene"
+NEXT_BROWSER_HEADLESS=1 next-browser open http://localhost:3457/
+next-browser snapshot
+
+# WITH the token: shows "My secret diagram (loaded!)"
+NEXT_BROWSER_HEADLESS=1 next-browser open http://localhost:3457/ \
+  --local-storage prototypes/auth-localstorage/localstorage.json
+next-browser snapshot
+```

--- a/prototypes/auth-localstorage/localstorage.json
+++ b/prototypes/auth-localstorage/localstorage.json
@@ -1,0 +1,1 @@
+{ "auth_token": "dev-token-xyz" }

--- a/prototypes/auth-localstorage/server.mjs
+++ b/prototypes/auth-localstorage/server.mjs
@@ -1,0 +1,80 @@
+// Minimal SPA-with-localStorage-token fixture for next-browser
+// --local-storage validation. Reproduces the Excalidraw+ scenario from
+// issue #13: the document loads (HTTP 200) but the app's data-fetching
+// layer authenticates with a token in localStorage, NOT a cookie — so
+// --cookies alone can't unlock the content.
+//
+// Run:  node server.mjs            (default port 3457)
+//       PORT=4000 node server.mjs
+//
+// Routes:
+//   GET /            — SPA shell. Inline JS reads localStorage.auth_token
+//                      and calls /api/scene with an Authorization header.
+//   GET /api/scene   — requires `Authorization: Bearer dev-token-xyz`.
+//                      Returns the scene JSON with it, 401 without.
+
+import { createServer } from "node:http";
+
+const PORT = Number(process.env.PORT) || 3457;
+const REQUIRED_TOKEN = "dev-token-xyz";
+
+const server = createServer((req, res) => {
+  const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
+
+  if (url.pathname === "/") {
+    res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    res.end(`<!doctype html>
+<html>
+  <head><title>auth-localstorage prototype</title></head>
+  <body>
+    <h1 data-test="shell-title">Scene viewer</h1>
+    <div data-test="scene-status">Loading scene…</div>
+    <script>
+      (async () => {
+        const status = document.querySelector('[data-test="scene-status"]');
+        const token = localStorage.getItem('auth_token');
+        try {
+          const r = await fetch('/api/scene', {
+            headers: token ? { authorization: 'Bearer ' + token } : {},
+          });
+          if (!r.ok) {
+            status.textContent = "We couldn't open this scene";
+            status.setAttribute('data-test-state', 'error');
+            return;
+          }
+          const scene = await r.json();
+          status.textContent = scene.title;
+          status.setAttribute('data-test-state', 'ok');
+        } catch (e) {
+          status.textContent = "We couldn't open this scene";
+          status.setAttribute('data-test-state', 'error');
+        }
+      })();
+    </script>
+  </body>
+</html>`);
+    return;
+  }
+
+  if (url.pathname === "/api/scene") {
+    const auth = req.headers.authorization ?? "";
+    const ok = auth === `Bearer ${REQUIRED_TOKEN}`;
+    if (!ok) {
+      res.writeHead(401, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "unauthorized" }));
+      return;
+    }
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ title: "My secret diagram (loaded!)" }));
+    return;
+  }
+
+  res.writeHead(404, { "content-type": "text/plain" });
+  res.end("not found");
+});
+
+server.listen(PORT, () => {
+  console.log(`auth-localstorage prototype listening on http://localhost:${PORT}`);
+  console.log(`  /           SPA shell (reads localStorage.auth_token)`);
+  console.log(`  /api/scene  requires Authorization: Bearer ${REQUIRED_TOKEN}`);
+});

--- a/skills/next-browser/SKILL.md
+++ b/skills/next-browser/SKILL.md
@@ -43,6 +43,11 @@ See https://nextjs.org/docs/app/guides/ai-agents for background.
   click any authenticated request, right-click → Copy → Copy as cURL,
   paste the whole thing into a file, and give me the path." That's it —
   no hand-editing, no JSON. The CLI parses the cURL for you.
+- If the site is a SPA whose content still won't load with cookies (the
+  shell loads but data calls 401), it likely authenticates via a
+  `localStorage` token. Ask the user to run
+  `copy(JSON.stringify(localStorage))` in the page's DevTools console,
+  save it to a file, and give you the path — then pass `--local-storage`.
 - Never ask the user to paste cookie values into chat; if they do, stop
   and ask them to save to a file instead. You must never echo, paste,
   or write cookie values yourself. See "Trust boundaries".
@@ -105,10 +110,12 @@ Two things that implies:
 
 ## Commands
 
-### `open <url> [--cookies <file>]`
+### `open <url> [--cookies <file>] [--local-storage <file>]`
 
 Launch browser, navigate to URL. With `--cookies`, sets auth cookies
-before navigating (domain derived from URL hostname).
+before navigating (domain derived from URL hostname). With
+`--local-storage`, seeds `localStorage` for the URL's origin before the
+first navigation. Both flags can be combined.
 
 ```
 $ next-browser open http://localhost:3024/vercel --cookies cookies.curl
@@ -125,10 +132,35 @@ The `--cookies` file can be any of three formats — the CLI auto-detects:
 3. **Playwright JSON** — `[{"name":"...","value":"..."}, ...]`. The
    old `--cookies-json` flag is kept as an alias for back-compat.
 
-**The user creates this file and gives you the path.** Never echo,
-paste, or write cookie values yourself — they are secrets and must not
-appear in your commands, transcript, or any file you create. See
-"Trust boundaries".
+**`--local-storage` — for SPAs that don't auth via cookies.** Many SPAs
+keep their auth token in `localStorage` (not a cookie), so the
+data-fetching layer fails even when the document loads with the right
+cookie. Seed those entries with `--local-storage <file>`:
+
+```
+$ next-browser open https://app.example.com/s/abc --local-storage tokens.json
+opened → https://app.example.com/s/abc (3 localStorage entries for app.example.com)
+```
+
+The file is JSON in either form:
+
+1. **Object** (easiest) — `{"key":"value", ...}`. This is exactly what
+   `JSON.stringify(localStorage)` produces, so the user can run
+   `copy(JSON.stringify(localStorage))` in the page's DevTools console
+   and paste the result into a file.
+2. **Array** — `[{"name":"...","value":"..."}, ...]` (also accepts
+   `key` instead of `name`). The `--local-storage-json` alias also works.
+
+The entries are re-seeded on every navigation/reload and are
+origin-guarded (never leak to other origins the SPA visits).
+`indexedDB`-based tokens are not yet supported — if a page still fails
+to load after seeding `localStorage`, check `network` for the failing
+data request and inspect what it authenticates with.
+
+**The user creates these files and gives you the path.** Never echo,
+paste, or write cookie or token values yourself — they are secrets and
+must not appear in your commands, transcript, or any file you create.
+See "Trust boundaries".
 
 ### `close`
 
@@ -1046,3 +1078,36 @@ If the shell is still empty after waiting, check:
   in the RSC payload, not a separate request.
 - Did `errors` surface any `unstable_instant` validation failures?
 - Is `unstable_prefetch = 'runtime'` exported from the correct segment?
+
+### Authenticated SPA loads the shell but not the content
+
+The page opens, the HTML shell renders (HTTP 200), but the actual
+content never appears — a viewer shows "couldn't load", a dashboard
+stays on its skeleton, an API panel is empty. The document request was
+authenticated, but the app's *data* request was not.
+
+This is the cookie-vs-token split. The cookie satisfies the document
+request, but many SPAs authenticate their data-fetching layer with a
+token in `localStorage` (or `indexedDB`), or an `Authorization` header
+derived from it — none of which `--cookies` supplies.
+
+**Workflow:**
+
+1. `network` — find the failing data request. A `401`/`403` on an
+   XHR/fetch while the document was `200` is the tell.
+2. Inspect that request (`network <idx>`). If it carries an
+   `Authorization: Bearer …` header or a custom token header rather than
+   relying on the cookie, the credential lives in client storage.
+3. Confirm with `eval 'Object.keys(localStorage)'` — a token-looking key
+   (`token`, `access_token`, `auth`, a JWT value) confirms it.
+4. Ask the user to capture it: run `copy(JSON.stringify(localStorage))`
+   in the page's DevTools console, save to a file, share the path. (Same
+   trust boundary as cookies — you handle the path, never the value.)
+5. Re-`open` with `--local-storage <file>` (combine with `--cookies` if
+   the document needs the cookie too). The token is seeded before the
+   first navigation, so the data request authenticates on first load.
+6. `network` again — the previously failing request should now be `200`.
+
+If the data request still fails after seeding `localStorage`, the token
+likely lives in `indexedDB` (not yet supported). Report that to the user
+with the specific failing request from `network` as evidence.

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -95,6 +95,39 @@ export async function cookies(cookies: { name: string; value: string }[], domain
   return cookies.length;
 }
 
+/**
+ * Seed localStorage for a specific origin before navigating. Many SPAs keep
+ * their auth token in localStorage (not cookies), so the data-fetching layer
+ * authenticates via a value that --cookies can't supply.
+ *
+ * Implemented with addInitScript so the entries are present before the page's
+ * own scripts run on the very first navigation — the same "before the first
+ * request" guarantee that cookies() provides. The script re-seeds on every
+ * navigation/reload, and is origin-guarded so tokens never leak to other
+ * origins the SPA might navigate to. Must be called after open() but before
+ * navigating to the target page.
+ */
+export async function setLocalStorage(
+  entries: { name: string; value: string }[],
+  origin: string,
+) {
+  if (!context) throw new Error("browser not open");
+  await context.addInitScript(
+    (data: { origin: string; entries: [string, string][] }) => {
+      try {
+        if (location.origin !== data.origin) return;
+        for (const [k, v] of data.entries) {
+          try {
+            window.localStorage.setItem(k, v);
+          } catch {}
+        }
+      } catch {}
+    },
+    { origin, entries: entries.map((e) => [e.name, e.value] as [string, string]) },
+  );
+  return entries.length;
+}
+
 /** Close the browser and reset all state. */
 export async function close() {
   await screenshotBrowser?.close().catch(() => {});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { send } from "./client.ts";
 import { parseCookies } from "./cookies.ts";
+import { parseLocalStorage } from "./storage.ts";
 
 const args = process.argv.slice(2);
 const cmd = args[0];
@@ -22,32 +23,55 @@ if (cmd === "--version" || cmd === "-v") {
 
 if (cmd === "open") {
   if (!arg) {
-    console.error("usage: next-browser open <url> [--cookies <file>]");
+    console.error("usage: next-browser open <url> [--cookies <file>] [--local-storage <file>]");
     process.exit(1);
   }
   const url = /^https?:\/\//.test(arg) ? arg : `http://${arg}`;
-  const cookieIdx = (() => {
-    const i = args.indexOf("--cookies");
-    if (i >= 0) return i;
-    return args.indexOf("--cookies-json"); // back-compat alias
-  })();
-  const cookieFile = cookieIdx >= 0 ? args[cookieIdx + 1] : undefined;
+  const flagValue = (...names: string[]) => {
+    for (const name of names) {
+      const i = args.indexOf(name);
+      if (i >= 0) return args[i + 1];
+    }
+    return undefined;
+  };
+  const cookieFile = flagValue("--cookies", "--cookies-json"); // -json kept for back-compat
+  const localStorageFile = flagValue("--local-storage", "--local-storage-json");
 
-  if (cookieFile) {
+  if (cookieFile || localStorageFile) {
     const res = await send("open");
     if (!res.ok) exit(res, "");
-    let cookies;
-    try {
-      cookies = parseCookies(readFileSync(cookieFile, "utf-8"));
-    } catch (e) {
-      console.error(`cookies: ${(e as Error).message}`);
-      process.exit(1);
-    }
     const domain = new URL(url).hostname;
-    const cRes = await send("cookies", { cookies, domain });
-    if (!cRes.ok) exit(cRes, "");
+    const origin = new URL(url).origin;
+    const summary: string[] = [];
+
+    if (cookieFile) {
+      let cookies;
+      try {
+        cookies = parseCookies(readFileSync(cookieFile, "utf-8"));
+      } catch (e) {
+        console.error(`cookies: ${(e as Error).message}`);
+        process.exit(1);
+      }
+      const cRes = await send("cookies", { cookies, domain });
+      if (!cRes.ok) exit(cRes, "");
+      summary.push(`${cookies.length} cookies`);
+    }
+
+    if (localStorageFile) {
+      let entries;
+      try {
+        entries = parseLocalStorage(readFileSync(localStorageFile, "utf-8"));
+      } catch (e) {
+        console.error(`local-storage: ${(e as Error).message}`);
+        process.exit(1);
+      }
+      const lRes = await send("local-storage", { entries, origin });
+      if (!lRes.ok) exit(lRes, "");
+      summary.push(`${entries.length} localStorage entries`);
+    }
+
     await send("goto", { url });
-    exit(res, `opened → ${url} (${cookies.length} cookies for ${domain})`);
+    exit(res, `opened → ${url} (${summary.join(", ")} for ${domain})`);
   }
 
   const res = await send("open", { url });
@@ -514,7 +538,7 @@ function printUsage() {
   console.error(
     "usage: next-browser <command> [args]\n" +
       "\n" +
-      "  open <url> [--cookies <file>]  launch browser and navigate\n" +
+      "  open <url> [--cookies <file>] [--local-storage <file>]  launch browser and navigate\n" +
       "  close              close browser and daemon\n" +
       "\n" +
       "  goto <url>         full-page navigation (new document load)\n" +

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -56,6 +56,8 @@ type Cmd = {
   idx?: number;
   cookies?: { name: string; value: string }[];
   domain?: string;
+  entries?: { name: string; value: string }[];
+  origin?: string;
   width?: number | null;
   height?: number | null;
   fullPage?: boolean;
@@ -69,6 +71,10 @@ async function run(cmd: Cmd) {
   }
   if (cmd.action === "cookies") {
     const data = await browser.cookies(cmd.cookies!, cmd.domain!);
+    return { ok: true, data };
+  }
+  if (cmd.action === "local-storage") {
+    const data = await browser.setLocalStorage(cmd.entries!, cmd.origin!);
     return { ok: true, data };
   }
   if (cmd.action === "lock") {

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,0 +1,57 @@
+export type StorageEntry = { name: string; value: string };
+
+/**
+ * Parse localStorage input in one of two JSON formats, auto-detected from
+ * the first non-whitespace character:
+ *
+ *   1. Object — `{"key": "value", ...}`. This is exactly what
+ *      `JSON.stringify(localStorage)` produces, so the easiest way for a
+ *      user to capture their tokens is to run `copy(JSON.stringify(localStorage))`
+ *      in the page's DevTools console and paste the result into a file.
+ *   2. Array — `[{"name": "x", "value": "y"}, ...]` (also accepts `key`
+ *      instead of `name`), mirroring the Playwright-style cookies format.
+ *
+ * localStorage values are always strings, so non-string values are rejected.
+ *
+ * Like the cookie parser, this never echoes a secret value back in an error
+ * message — error text mentions the key or index, not the contents.
+ */
+export function parseLocalStorage(raw: string): StorageEntry[] {
+  const trimmed = raw.trim();
+  if (!trimmed) throw new Error("local-storage file is empty");
+
+  let data: unknown;
+  try {
+    data = JSON.parse(trimmed);
+  } catch {
+    throw new Error(
+      'local-storage file must be JSON — either {"key":"value", …} (run copy(JSON.stringify(localStorage)) in the console) or [{"name":"…","value":"…"}, …]',
+    );
+  }
+
+  if (Array.isArray(data)) {
+    return data.map((e, i) => {
+      const entry = e as { name?: unknown; key?: unknown; value?: unknown } | null;
+      const name = entry && (typeof entry.name === "string" ? entry.name : entry.key);
+      const value = entry?.value;
+      if (typeof name !== "string" || typeof value !== "string") {
+        throw new Error(`local-storage[${i}] must have a string name (or key) and value`);
+      }
+      return { name, value };
+    });
+  }
+
+  if (data && typeof data === "object") {
+    const entries: StorageEntry[] = [];
+    for (const [name, value] of Object.entries(data as Record<string, unknown>)) {
+      if (typeof value !== "string") {
+        throw new Error(`local-storage["${name}"] value must be a string`);
+      }
+      entries.push({ name, value });
+    }
+    if (entries.length === 0) throw new Error("no localStorage entries found in input");
+    return entries;
+  }
+
+  throw new Error("local-storage JSON must be an object or array");
+}


### PR DESCRIPTION
Closes #13.

## Problem

SPAs that authenticate their data-fetching layer with a token in `localStorage` (not a cookie) load the document fine with `--cookies` — HTTP 200 on the shell — but the app's subsequent API calls 401, so the content never appears (the Excalidraw+ "We couldn't open this scene" case in the issue).

## Solution

Add `open --local-storage <file>`, mirroring `--cookies`:

```
next-browser open https://app.example.com/s/abc --local-storage tokens.json
opened → https://app.example.com/s/abc (3 localStorage entries for app.example.com)
```

- **Seeded before the first navigation** via `addInitScript`, so the token is present when the SPA's first `fetch` runs — the same "before the first request" guarantee `--cookies` gives.
- **Origin-guarded** — entries are only applied on the target origin, never leaked to other origins the SPA navigates to. Re-seeded on every navigation/reload.
- **Combines with `--cookies`** — `opened → … (2 cookies, 3 localStorage entries for …)`.
- **Two input formats**, auto-detected: an object `{"key":"value", …}` (exactly what `copy(JSON.stringify(localStorage))` produces in DevTools) or a Playwright-style array `[{"name","value"}, …]` (`key` also accepted). The `--local-storage-json` alias works too.
- **Secrets never echoed** — the parser references the key/index in errors, never the value, consistent with the cookie parser and the skill's trust boundaries.

`indexedDB`-based tokens remain out of scope; the new SKILL.md scenario tells the agent to detect that case via `network` and report it.

## Validation

New `prototypes/auth-localstorage` fixture reproduces the issue (SPA reads `localStorage.auth_token`, fetches `/api/scene` with a Bearer header). Verified end-to-end against the built CLI:

| Case | Result |
| ------------------------------------- | ----------------------------------------------- |
| `open` (no flag)                      | `token=null` → "We couldn't open this scene"    |
| `open --local-storage tokens.json`    | `token=dev-token-xyz` → "My secret diagram (loaded!)" |
| array format + `--cookies` combined   | both applied; scene loads, cookies + theme set  |
| invalid JSON / non-string / missing   | clean `local-storage: …` error, exit 1, no value leak |

## Changes

- `src/storage.ts` — `parseLocalStorage` (new)
- `src/browser.ts` — `setLocalStorage` via origin-guarded `addInitScript`
- `src/daemon.ts` — `local-storage` action
- `src/cli.ts` — `--local-storage` flag, refactored `open` to apply cookies and/or localStorage
- `skills/next-browser/SKILL.md` — command docs, onboarding note, "Authenticated SPA loads the shell but not the content" scenario
- `README.md` — command table
- `prototypes/auth-localstorage/` — validation fixture
